### PR TITLE
Toned-down shared styling

### DIFF
--- a/exercise-calculators/barbell-complex-workout.html
+++ b/exercise-calculators/barbell-complex-workout.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Barbell Complex Workout</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/exercise-calculators/heavy-lifting-timer.html
+++ b/exercise-calculators/heavy-lifting-timer.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Workout Set 1 - Rest Timers</title>
+    <link rel="stylesheet" href="../style.css">
 
   <!-- Google Font -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/exercise-calculators/index.html
+++ b/exercise-calculators/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Exercise Calculators & Tools</title>
+    <link rel="stylesheet" href="../style.css">
     <style>
         body { font-family: sans-serif; margin: 20px; background-color: #f4f4f9; color: #333; }
         .container { max-width: 800px; margin: auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }

--- a/exercise-calculators/strength-rehab-plan.html
+++ b/exercise-calculators/strength-rehab-plan.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Morning Strength & Evening Rehab Plan</title>
+    <link rel="stylesheet" href="../style.css">
   <style>
     :root {
       --bg: #f0f2f5;

--- a/health-calculators/GBScaleCalc.html
+++ b/health-calculators/GBScaleCalc.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Glasgow Blatchford Score (GBS) Calculator</title>
+    <link rel="stylesheet" href="../style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
   <style>

--- a/health-calculators/anion-gap-calculator.html
+++ b/health-calculators/anion-gap-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Anion Gap Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/apgar-score-calculator.html
+++ b/health-calculators/apgar-score-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>APGAR Score Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/ballard-score-calculator.html
+++ b/health-calculators/ballard-score-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>New Ballard Score Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/bishop-score-calculator.html
+++ b/health-calculators/bishop-score-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bishop Score Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/bmi-calculator.html
+++ b/health-calculators/bmi-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>BMI Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/bsa-calculator.html
+++ b/health-calculators/bsa-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>BSA Calculator (Mosteller)</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/cha2ds2vasc-calculator.html
+++ b/health-calculators/cha2ds2vasc-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CHA2DS2-VASc Score Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/clinical-frailty-scale.html
+++ b/health-calculators/clinical-frailty-scale.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Clinical Frailty Scale (CFS)</title>
+    <link rel="stylesheet" href="../style.css">
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;

--- a/health-calculators/corrected-calcium-calculator.html
+++ b/health-calculators/corrected-calcium-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Corrected Calcium Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/curb65-calculator.html
+++ b/health-calculators/curb65-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CURB-65 Score Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/edd-calculator.html
+++ b/health-calculators/edd-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Estimated Due Date (EDD) Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/fetal-weight-calculator.html
+++ b/health-calculators/fetal-weight-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fetal Weight Estimation Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/fullpiers-calculator.html
+++ b/health-calculators/fullpiers-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>fullPIERS Pre-eclampsia Risk Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/gcs-calculator.html
+++ b/health-calculators/gcs-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Glasgow Coma Scale (GCS) Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/gdm-risk-calculator.html
+++ b/health-calculators/gdm-risk-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gestational Diabetes (GDM) Risk Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/hasbled-calculator.html
+++ b/health-calculators/hasbled-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HAS-BLED Score Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/index.html
+++ b/health-calculators/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Health Calculators</title>
+    <link rel="stylesheet" href="../style.css">
     <style>
         body { font-family: sans-serif; margin: 20px; background-color: #f4f4f9; color: #333; }
         .container { max-width: 800px; margin: auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }

--- a/health-calculators/iv-drip-rate-calculator.html
+++ b/health-calculators/iv-drip-rate-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>IV Drip Rate Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/meows-calculator.html
+++ b/health-calculators/meows-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>UK National Maternity Early Warning Score (MEWS) Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/neonatal-bilirubin-calculator.html
+++ b/health-calculators/neonatal-bilirubin-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Neonatal Bilirubin Risk Calculator (Bhutani Nomogram)</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/news2-calculator.html
+++ b/health-calculators/news2-calculator.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NEWS2 Calculator</title>
+    <link rel="stylesheet" href="../style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
     <style>

--- a/health-calculators/nrp-guide-tool.html
+++ b/health-calculators/nrp-guide-tool.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NRP Guided Tool</title>
+    <link rel="stylesheet" href="../style.css">
     <!-- Tailwind CSS via CDN is for your example; I will translate this to standard CSS -->
     <!-- <script src="https://cdn.tailwindcss.com"></script> -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Workout Tracker</title>
+  <link rel="stylesheet" href="style.css">
 
   <!-- Google Font -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -24,8 +25,8 @@
     body {
       font-family: "Montserrat", sans-serif;
       text-align: center;
-      background: linear-gradient(135deg, #000000, #333333);
-      color: #fff;
+      background-color: #f5f5f5;
+      color: #333;
       min-height: 100vh;
       display: flex;
       flex-direction: column;
@@ -40,7 +41,7 @@
       margin: 1rem 0;
       font-weight: 700;
       text-shadow: 1px 1px 3px rgba(0,0,0,0.6);
-      color: #FFD700; /* Gold accent for heading */
+      color: #2c5f2d; /* Heading color */
     }
 
     /* SUBTEXT / INTRO */
@@ -53,7 +54,7 @@
 
     h2 { /* Styling for the new section headings */
       font-size: 1.8rem;
-      color: #FFD700; /* Gold to match main heading */
+      color: #2c5f2d; /* Section heading color */
       margin-top: 2rem;
       margin-bottom: 0.5rem;
       text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
@@ -61,8 +62,8 @@
 
     /* QUOTE BOX */
     .quote-container {
-      background: rgba(255, 215, 0, 0.1); /* Subtle gold overlay */
-      border: 1px solid rgba(255, 215, 0, 0.3);
+        background: #fff;
+      border: 1px solid #ccc;
       border-radius: 8px;
       padding: 1.5rem;
       margin: 1rem auto 2rem;
@@ -76,21 +77,21 @@
       font-style: italic;
       margin-bottom: 0.8rem;
       line-height: 1.4;
-      color: #FFD700; /* Gold for the quote text */
+      color: #2c5f2d; /* Quote text color */
     }
 
     .quote-author {
       font-size: 1rem;
       font-weight: 500;
       text-align: right;
-      color: #fff;
+      color: #333;
     }
 
     /* LINK BUTTONS */
     a {
       text-decoration: none;
-      color: #000; /* Black text on gold background */
-      background: #FFD700; /* Gold button */
+      color: #000; /* Button text color */
+      background: #e0e0e0; /* Button background */
       padding: 12px 24px;
       border-radius: 5px;
       margin: 10px;
@@ -100,7 +101,7 @@
       font-weight: 600;
     }
     a:hover {
-      background: #FFC107; /* Slightly brighter gold on hover */
+      background: #d6d6d6; /* Lighter shade on hover */
       color: #000;
     }
 
@@ -207,7 +208,7 @@
     });
   </script>
   <div style="text-align: center; margin-top: 30px; padding-bottom: 20px;">
-    <a href="https://github.com/gwavin/Fitness/edit/main/index.html" target="_blank" style="color: #FFD700; text-decoration: none; font-size: 0.9rem;">✏️ Edit this page on GitHub</a>
+    <a href="https://github.com/gwavin/Fitness/edit/main/index.html" target="_blank" style="color: #2c5f2d; text-decoration: none; font-size: 0.9rem;">✏️ Edit this page on GitHub</a>
   </div>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,11 @@
+body {
+    font-family: 'Montserrat', sans-serif;
+    background-color: #f5f5f5;
+    color: #333;
+}
+
+a,
+button {
+    color: #2c5f2d;
+}
+


### PR DESCRIPTION
## Summary
- add a common `style.css` with neutral palette
- link new stylesheet from home page, health calculators and exercise calculators
- remove gold accents and gradient background from `index.html`

## Testing
- `curl -s http://localhost:8765/index.html | head`
- `curl -s http://localhost:8765/health-calculators/bmi-calculator.html | grep -m1 style.css`
- `curl -s http://localhost:8765/exercise-calculators/heavy-lifting-timer.html | grep -m1 style.css`

------
https://chatgpt.com/codex/tasks/task_e_685b039d7954832ba60f62e699fccbc8