### PR TITLE
Fix CSS and remove external links

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -4,12 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Surprise Demo Page</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link
-    rel="stylesheet"
-    href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap"
-  />
-  <link rel="stylesheet" href="style.css">
 <style>
 
     /* THEMES */
@@ -144,7 +138,6 @@
   <a href="index.html" class="home-link">Back to Home</a>
 
   <div style="text-align: center; margin-top: 30px; padding-bottom: 20px;">
-    <a href="https://github.com/gwavin/Fitness/edit/main/demo.html" target="_blank" id="edit-link" style="text-decoration: none; font-size: 0.9rem;">✏️ Edit this page on GitHub</a>
   </div>
 
   <script>

--- a/exercise-calculators/barbell-complex-workout.html
+++ b/exercise-calculators/barbell-complex-workout.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Barbell Complex Workout</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.7;
@@ -129,7 +125,6 @@
 
         <a href="index.html" class="home-link">Back to Home</a>
 
-        <a href="https://github.com/gwavin/Fitness/edit/main/barbell-complex-workout.html" target="_blank" class="edit-github-link">✏️ Edit this page on GitHub</a>
     </div>
 </body>
 </html>

--- a/exercise-calculators/heavy-lifting-timer.html
+++ b/exercise-calculators/heavy-lifting-timer.html
@@ -4,16 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Workout Set 1 - Rest Timers</title>
-    <link rel="stylesheet" href="../style.css">
 
-  <!-- Google Font -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link
-    rel="stylesheet"
-    href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap"
-  >
-  
-  <link rel="stylesheet" href="../style.css">
 <style>
 
     body {
@@ -371,7 +362,6 @@
   </div>
 
   <div style="text-align: center; margin-top: 30px; padding-bottom: 20px;">
-    <a href="https://github.com/gwavin/Fitness/edit/main/heavy-lifting-timer.html" target="_blank" class="edit-github-link">✏️ Edit this page on GitHub</a>
   </div>
 
   <script>

--- a/exercise-calculators/hotel-room-workout.html
+++ b/exercise-calculators/hotel-room-workout.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hotel Room Workout</title>
-  <link rel="stylesheet" href="../style.css">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
   <style>
     body {
       line-height: 1.6;
@@ -101,7 +98,6 @@
     <p class="note">Adjust reps if needed and stop if shoulder pain increases.</p>
 
     <a class="home-link" href="index.html">Back to Exercise Tools</a>
-    <a class="edit-link" href="https://github.com/gwavin/Fitness/edit/main/exercise-calculators/hotel-room-workout.html" target="_blank">✏️ Edit this page on GitHub</a>
   </div>
 </body>
 </html>

--- a/exercise-calculators/index.html
+++ b/exercise-calculators/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Exercise Calculators & Tools</title>
-    <link rel="stylesheet" href="../style.css">
+<style>
         body { font-family: sans-serif; margin: 20px; background-color: #f4f4f9; color: #333; }
         .container { max-width: 800px; margin: auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
         h1 { color: #2c3e50; }

--- a/exercise-calculators/strength-rehab-plan.html
+++ b/exercise-calculators/strength-rehab-plan.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Morning Strength & Evening Rehab Plan</title>
+<style>
 
     :root {
       --bg: #f0f2f5;
@@ -34,7 +35,6 @@
   <div class="container">
     <h1>Morning Strength & Evening Rehab Plan</h1>
     <div class="edit-link" style="text-align: center; margin-bottom: 1rem;">
-      <a href="https://github.com/gwavin/Fitness/edit/main/strength-rehab-plan.html" target="_blank">✏️ Edit this plan on GitHub</a>
     </div>
     <div class="notes">
       <h2>Program Notes & Rehab Guidance</h2>

--- a/health-calculators/GBScaleCalc.html
+++ b/health-calculators/GBScaleCalc.html
@@ -3,10 +3,6 @@
 <head>
   <meta charset="UTF-8" />
   <title>Glasgow Blatchford Score (GBS) Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-  <link rel="stylesheet" href="../style.css">
 <style>
     body {
         line-height: 1.6;
@@ -347,7 +343,6 @@
 
 <div class="links">
     <a href="index.html">Back to Home</a>
-    <a href="https://github.com/gwavin/Fitness/edit/main/GBScaleCalc.html" target="_blank">✏️ Edit this page</a>
 </div>
 
   <script>
@@ -487,7 +482,6 @@
     });
   </script>
   <div style="text-align: center; margin-top: 30px; padding-bottom: 20px;">
-    <a href="https://github.com/gwavin/Fitness/edit/main/GBScaleCalc.html" target="_blank" style="color: #007BFF; text-decoration: none; font-size: 0.9rem;">✏️ Edit this page on GitHub</a>
   </div>
 </body>
 </html>

--- a/health-calculators/anion-gap-calculator.html
+++ b/health-calculators/anion-gap-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Anion Gap Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -135,7 +131,6 @@
     </div>
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/anion-gap-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/apgar-score-calculator.html
+++ b/health-calculators/apgar-score-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>APGAR Score Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -174,7 +170,6 @@
     </div>
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/apgar-score-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/ballard-score-calculator.html
+++ b/health-calculators/ballard-score-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>New Ballard Score Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -302,7 +298,6 @@
     </div>
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/ballard-score-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/bishop-score-calculator.html
+++ b/health-calculators/bishop-score-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bishop Score Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -177,7 +173,6 @@
     </div>
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/bishop-score-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/bmi-calculator.html
+++ b/health-calculators/bmi-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>BMI Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -145,7 +141,6 @@
     </div>
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/bmi-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/bsa-calculator.html
+++ b/health-calculators/bsa-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>BSA Calculator (Mosteller)</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -119,7 +115,6 @@
     </div>
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/bsa-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/cha2ds2vasc-calculator.html
+++ b/health-calculators/cha2ds2vasc-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CHA2DS2-VASc Score Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -192,7 +188,6 @@
     </div>
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/cha2ds2vasc-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/clinical-frailty-scale.html
+++ b/health-calculators/clinical-frailty-scale.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Clinical Frailty Scale (CFS)</title>
-    <link rel="stylesheet" href="../style.css">
+<style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
             line-height: 1.6;

--- a/health-calculators/corrected-calcium-calculator.html
+++ b/health-calculators/corrected-calcium-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Corrected Calcium Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -131,7 +127,6 @@
     </div>
      <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/corrected-calcium-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/curb65-calculator.html
+++ b/health-calculators/curb65-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CURB-65 Score Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -189,7 +185,6 @@
     </div>
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/curb65-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/edd-calculator.html
+++ b/health-calculators/edd-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Estimated Due Date (EDD) Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -133,7 +129,6 @@
     </div>
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/edd-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/fetal-weight-calculator.html
+++ b/health-calculators/fetal-weight-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fetal Weight Estimation Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -146,7 +142,6 @@
 
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/fetal-weight-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/fullpiers-calculator.html
+++ b/health-calculators/fullpiers-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>fullPIERS Pre-eclampsia Risk Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -170,7 +166,6 @@
 
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/fullpiers-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/gcs-calculator.html
+++ b/health-calculators/gcs-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Glasgow Coma Scale (GCS) Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -174,7 +170,6 @@
     </div>
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/gcs-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/gdm-risk-calculator.html
+++ b/health-calculators/gdm-risk-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gestational Diabetes (GDM) Risk Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -371,7 +367,6 @@
 
      <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/gdm-risk-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/hasbled-calculator.html
+++ b/health-calculators/hasbled-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HAS-BLED Score Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -205,7 +201,6 @@
     </div>
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/hasbled-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/index.html
+++ b/health-calculators/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Health Calculators</title>
-    <link rel="stylesheet" href="../style.css">
+<style>
 
         body { font-family: sans-serif; margin: 20px; background-color: #f4f4f9; color: #333; }
         .container { max-width: 800px; margin: auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }

--- a/health-calculators/iv-drip-rate-calculator.html
+++ b/health-calculators/iv-drip-rate-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>IV Drip Rate Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -156,7 +152,6 @@
     </div>
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/iv-drip-rate-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/meows-calculator.html
+++ b/health-calculators/meows-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>UK National Maternity Early Warning Score (MEWS) Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -252,7 +248,6 @@
     </div>
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/meows-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/neonatal-bilirubin-calculator.html
+++ b/health-calculators/neonatal-bilirubin-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Neonatal Bilirubin Risk Calculator (Bhutani Nomogram)</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -218,7 +214,6 @@
 
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/neonatal-bilirubin-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/news2-calculator.html
+++ b/health-calculators/news2-calculator.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NEWS2 Calculator</title>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         body {
             line-height: 1.6;
@@ -189,7 +185,6 @@
     </div>
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/news2-calculator.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/health-calculators/nrp-guide-tool.html
+++ b/health-calculators/nrp-guide-tool.html
@@ -4,12 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NRP Guided Tool</title>
-    <link rel="stylesheet" href="../style.css">
     <!-- Tailwind CSS via CDN is for your example; I will translate this to standard CSS -->
     <!-- <script src="https://cdn.tailwindcss.com"></script> -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;600;700&family=Roboto+Mono:wght@400;700&display=swap">
-    <link rel="stylesheet" href="../style.css">
 <style>
         /* General Body Styles */
         body {
@@ -397,7 +393,6 @@
 
     <div class="links">
         <a href="index.html">Back to Home</a>
-        <a href="https://github.com/gwavin/Fitness/edit/main/nrp-guide-tool.html" target="_blank">✏️ Edit this page</a>
     </div>
 
     <script>

--- a/index.html
+++ b/index.html
@@ -4,16 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Workout Tracker</title>
-  <link rel="stylesheet" href="style.css">
 
-  <!-- Google Font -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link
-    rel="stylesheet"
-    href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap"
-  />
-
-  <link rel="stylesheet" href="style.css">
 <style>
 
     /* BODY STYLES - DARK BACKGROUND WITH A SUBTLE GRADIENT */
@@ -127,26 +118,22 @@
   <h1>Workout Tracker</h1>
   <div class="subtitle">
     Fuel your ambition. Strengthen your mind. Become unstoppable!
-  </div>
 
   <!-- QUOTE BOX -->
   <div class="quote-container fade-enter" id="quote-container">
     <div class="quote-text" id="quote-text"></div>
     <div class="quote-author" id="quote-author"></div>
-  </div>
 
   <h2>Calculators & Tools</h2>
   <div class="link-container">
     <a href="health-calculators/index.html">Health Calculators</a>
     <a href="exercise-calculators/index.html">Exercise Calculators & Tools</a>
-  </div>
 
   <h2>Other Pages</h2>
   <div class="link-container">
     <a href="waffles2.html">Waffles Recipe</a>
     <a href="myPlan.html">Movie Plan</a>
     <a href="demo.html">Surprise Demo</a>
-  </div>
 
   <script>
     // Array of quotes (Jordan Peterson, Joe Rogan, Marcus Aurelius)
@@ -201,8 +188,5 @@
       });
     });
   </script>
-  <div style="text-align: center; margin-top: 30px; padding-bottom: 20px;">
-    <a href="https://github.com/gwavin/Fitness/edit/main/index.html" target="_blank" style="color: #2c5f2d; text-decoration: none; font-size: 0.9rem;">✏️ Edit this page on GitHub</a>
-  </div>
 </body>
 </html>

--- a/myPlan.html
+++ b/myPlan.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Documentary Treatment: Watson - The Duel in the Sun and Beyond</title>
-    <link rel="stylesheet" href="style.css">
 <style>
         body {
             font-family: 'Arial', sans-serif;
@@ -184,7 +183,6 @@
         </div>
     </div>
     <div style="text-align: center; margin-top: 30px; padding-bottom: 20px;">
-      <a href="https://github.com/gwavin/Fitness/edit/main/myPlan.html" target="_blank" style="color: #2c5f2d; text-decoration: none; font-size: 0.9rem;">✏️ Edit this page on GitHub</a>
     </div>
 </body>
 </html>

--- a/waffles.html
+++ b/waffles.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <title>Slightly Sweet Soured‑Milk Waffles</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" href="style.css">
 <style>
     body{font-family:system-ui,Arial,sans-serif;max-width:750px;margin:0 auto;padding:1rem;line-height:1.6}
     h1,h2{color:#333;margin-bottom:.3em}

--- a/waffles2.html
+++ b/waffles2.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <title>Perfected Soured-Milk Waffles</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" href="style.css">
 <style>
     body {
       font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
@@ -112,7 +111,6 @@
     <li>The finished batter keeps for 24 hours in the fridge. Note that it will deflate slightly, resulting in a slightly less airy waffle.</li>
   </ul>
   <div style="text-align: center; margin-top: 30px; padding-bottom: 20px;">
-    <a href="https://github.com/gwavin/Fitness/edit/main/waffles2.html" target="_blank" style="color: #333; text-decoration: none; font-size: 0.9rem;">✏️ Edit this page on GitHub</a>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- clean up broken Google Font links and remove references to `style.css`
- drop GitHub edit links from HTML pages
- add missing `<style>` blocks so CSS works again

## Testing
- `python3 -m py_compile $(git ls-files '*.py')` *(fails: no files to compile)*

------
https://chatgpt.com/codex/tasks/task_e_685b0a49f82c832bbcb8a524d858ceeb