### PR TITLE
Fix links from workout calendar

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -90,7 +90,9 @@
                 cell.classList.add('rest-day');
                 cell.innerHTML = `${dayOfMonth} ${month}<br>Rest`;
             } else {
-
+                const dayOfWeek = currentDate.toLocaleString('default', { weekday: 'short' });
+                const isoDate = currentDate.toISOString().split('T')[0];
+                const link = `workouts/${isoDate}.html`;
                 cell.innerHTML = `<a href="${link}">${dayOfMonth} ${month}<br>${dayOfWeek}</a>`;
             }
 


### PR DESCRIPTION
## Summary
- wire up links in `calendar.html` so each day points to the workouts in `/workouts`

## Testing
- `python3 -m http.server 8000` *(manual check)*

------
https://chatgpt.com/codex/tasks/task_e_687d6269fac0832bbe1dbde9d5c7aefa