### PR TITLE
Fix broken workout links and expand mobility plan

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -86,14 +86,15 @@
             const dayOfMonth = currentDate.getDate();
             const month = currentDate.toLocaleString('default', { month: 'short' });
 
-            if (currentDate.getDay() === 0) { // Sunday
-                cell.classList.add('rest-day');
-                cell.innerHTML = `${dayOfMonth} ${month}<br>Rest`;
-            } else {
+            const dayOfWeekIndex = currentDate.getDay();
+            if (dayOfWeekIndex === 1 || dayOfWeekIndex === 3 || dayOfWeekIndex === 5) {
                 const dayOfWeek = currentDate.toLocaleString('default', { weekday: 'short' });
                 const isoDate = currentDate.toISOString().split('T')[0];
                 const link = `workouts/${isoDate}.html`;
                 cell.innerHTML = `<a href="${link}">${dayOfMonth} ${month}<br>${dayOfWeek}</a>`;
+            } else {
+                cell.classList.add('rest-day');
+                cell.innerHTML = `${dayOfMonth} ${month}<br>Rest`;
             }
 
             row.appendChild(cell);

--- a/exercise-plan.html
+++ b/exercise-plan.html
@@ -135,8 +135,10 @@
     <li>Door‑frame pec stretch – 60 s/side</li>
     <li>Thoracic cat‑camel – 1 min</li>
     <li>Bretzel stretch – 1 min/side</li>
-    <li>Banded shoulder ER/IR (External/Internal Rotation) – 2×20</li>
+    <li>Banded shoulder ER/IR – 2×20</li>
     <li>Deep squat pry – 1 min total, move around</li>
+    <li>Ankle circles – 10 each direction per side</li>
+    <li>Wall calf stretch – 30 s/side</li>
     </ul>
 
     <h2 id="safety">Progress &amp; Safety Guidelines</h2>

--- a/workouts/2025-07-23.html
+++ b/workouts/2025-07-23.html
@@ -74,5 +74,6 @@
         </div>
     </div>
 
+<p><a href="../calendar.html">Back to Calendar</a></p>
 </body>
 </html>

--- a/workouts/2025-07-25.html
+++ b/workouts/2025-07-25.html
@@ -74,5 +74,6 @@
         </div>
     </div>
 
+<p><a href="../calendar.html">Back to Calendar</a></p>
 </body>
 </html>

--- a/workouts/2025-07-28.html
+++ b/workouts/2025-07-28.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Monday, July 28</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,7 +17,7 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
+    <h1>Your Workout for Monday, July 28</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
 
     <div class="workout-section">

--- a/workouts/2025-07-30.html
+++ b/workouts/2025-07-30.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Wednesday, July 30</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,8 +17,8 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
-    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+    <h1>Your Workout for Wednesday, July 30</h1>
+    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>
@@ -41,23 +41,23 @@
     <div class="workout-section">
         <h2>Main Workout (30-35 minutes)</h2>
         <div class="exercise">
-            <p class="exercise-name">A1: Goblet Squats</p>
-            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on keeping your chest up and back straight.</p>
-        </div>
-        <div class="exercise">
-            <p class="exercise-name">B1: Dumbbell Rows</p>
+            <p class="exercise-name">A1: Dumbbell Rows</p>
             <p class="sets-reps">4 sets of 10-12 reps per arm. Rest 60 seconds.</p>
             <p class="notes">Keep your back flat and pull the dumbbell towards your hip.</p>
         </div>
         <div class="exercise">
-            <p class="exercise-name">C1: Romanian Deadlifts (RDLs)</p>
-            <p class="sets-reps">3 sets of 12-15 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on pushing your hips back. Use light weight to start.</p>
+            <p class="exercise-name">B1: Goblet Squats</p>
+            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
+            <p class="notes">Focus on keeping your chest up and back straight.</p>
         </div>
         <div class="exercise">
-            <p class="exercise-name">D1: Plank</p>
+            <p class="exercise-name">C1: Plank</p>
             <p class="sets-reps">3 sets, hold for 30-45 seconds. Rest 45 seconds.</p>
+        </div>
+        <div class="exercise">
+            <p class="exercise-name">D1: Romanian Deadlifts (RDLs)</p>
+            <p class="sets-reps">3 sets of 12-15 reps. Rest 60 seconds.</p>
+            <p class="notes">Focus on pushing your hips back. Use light weight to start.</p>
         </div>
     </div>
 

--- a/workouts/2025-08-01.html
+++ b/workouts/2025-08-01.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Friday, August 1</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,8 +17,8 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
-    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+    <h1>Your Workout for Friday, August 1</h1>
+    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>
@@ -41,9 +41,9 @@
     <div class="workout-section">
         <h2>Main Workout (30-35 minutes)</h2>
         <div class="exercise">
-            <p class="exercise-name">A1: Goblet Squats</p>
-            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on keeping your chest up and back straight.</p>
+            <p class="exercise-name">A1: Dumbbell Lunges</p>
+            <p class="sets-reps">4 sets of 10-12 reps per leg. Rest 60 seconds.</p>
+            <p class="notes">Focus on keeping your torso upright.</p>
         </div>
         <div class="exercise">
             <p class="exercise-name">B1: Dumbbell Rows</p>

--- a/workouts/2025-08-04.html
+++ b/workouts/2025-08-04.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Monday, August 4</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,7 +17,7 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
+    <h1>Your Workout for Monday, August 4</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
 
     <div class="workout-section">

--- a/workouts/2025-08-06.html
+++ b/workouts/2025-08-06.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Wednesday, August 6</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,8 +17,8 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
-    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+    <h1>Your Workout for Wednesday, August 6</h1>
+    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>
@@ -41,23 +41,23 @@
     <div class="workout-section">
         <h2>Main Workout (30-35 minutes)</h2>
         <div class="exercise">
-            <p class="exercise-name">A1: Goblet Squats</p>
-            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on keeping your chest up and back straight.</p>
-        </div>
-        <div class="exercise">
-            <p class="exercise-name">B1: Dumbbell Rows</p>
+            <p class="exercise-name">A1: Dumbbell Rows</p>
             <p class="sets-reps">4 sets of 10-12 reps per arm. Rest 60 seconds.</p>
             <p class="notes">Keep your back flat and pull the dumbbell towards your hip.</p>
         </div>
         <div class="exercise">
-            <p class="exercise-name">C1: Romanian Deadlifts (RDLs)</p>
-            <p class="sets-reps">3 sets of 12-15 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on pushing your hips back. Use light weight to start.</p>
+            <p class="exercise-name">B1: Goblet Squats</p>
+            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
+            <p class="notes">Focus on keeping your chest up and back straight.</p>
         </div>
         <div class="exercise">
-            <p class="exercise-name">D1: Plank</p>
+            <p class="exercise-name">C1: Plank</p>
             <p class="sets-reps">3 sets, hold for 30-45 seconds. Rest 45 seconds.</p>
+        </div>
+        <div class="exercise">
+            <p class="exercise-name">D1: Romanian Deadlifts (RDLs)</p>
+            <p class="sets-reps">3 sets of 12-15 reps. Rest 60 seconds.</p>
+            <p class="notes">Focus on pushing your hips back. Use light weight to start.</p>
         </div>
     </div>
 

--- a/workouts/2025-08-08.html
+++ b/workouts/2025-08-08.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Friday, August 8</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,8 +17,8 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
-    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+    <h1>Your Workout for Friday, August 8</h1>
+    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>
@@ -41,9 +41,9 @@
     <div class="workout-section">
         <h2>Main Workout (30-35 minutes)</h2>
         <div class="exercise">
-            <p class="exercise-name">A1: Goblet Squats</p>
-            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on keeping your chest up and back straight.</p>
+            <p class="exercise-name">A1: Dumbbell Lunges</p>
+            <p class="sets-reps">4 sets of 10-12 reps per leg. Rest 60 seconds.</p>
+            <p class="notes">Focus on keeping your torso upright.</p>
         </div>
         <div class="exercise">
             <p class="exercise-name">B1: Dumbbell Rows</p>

--- a/workouts/2025-08-11.html
+++ b/workouts/2025-08-11.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Monday, August 11</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,7 +17,7 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
+    <h1>Your Workout for Monday, August 11</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
 
     <div class="workout-section">

--- a/workouts/2025-08-13.html
+++ b/workouts/2025-08-13.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Wednesday, August 13</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,8 +17,8 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
-    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+    <h1>Your Workout for Wednesday, August 13</h1>
+    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>
@@ -41,23 +41,23 @@
     <div class="workout-section">
         <h2>Main Workout (30-35 minutes)</h2>
         <div class="exercise">
-            <p class="exercise-name">A1: Goblet Squats</p>
-            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on keeping your chest up and back straight.</p>
-        </div>
-        <div class="exercise">
-            <p class="exercise-name">B1: Dumbbell Rows</p>
+            <p class="exercise-name">A1: Dumbbell Rows</p>
             <p class="sets-reps">4 sets of 10-12 reps per arm. Rest 60 seconds.</p>
             <p class="notes">Keep your back flat and pull the dumbbell towards your hip.</p>
         </div>
         <div class="exercise">
-            <p class="exercise-name">C1: Romanian Deadlifts (RDLs)</p>
-            <p class="sets-reps">3 sets of 12-15 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on pushing your hips back. Use light weight to start.</p>
+            <p class="exercise-name">B1: Goblet Squats</p>
+            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
+            <p class="notes">Focus on keeping your chest up and back straight.</p>
         </div>
         <div class="exercise">
-            <p class="exercise-name">D1: Plank</p>
+            <p class="exercise-name">C1: Plank</p>
             <p class="sets-reps">3 sets, hold for 30-45 seconds. Rest 45 seconds.</p>
+        </div>
+        <div class="exercise">
+            <p class="exercise-name">D1: Romanian Deadlifts (RDLs)</p>
+            <p class="sets-reps">3 sets of 12-15 reps. Rest 60 seconds.</p>
+            <p class="notes">Focus on pushing your hips back. Use light weight to start.</p>
         </div>
     </div>
 

--- a/workouts/2025-08-15.html
+++ b/workouts/2025-08-15.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Friday, August 15</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,8 +17,8 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
-    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+    <h1>Your Workout for Friday, August 15</h1>
+    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>
@@ -41,9 +41,9 @@
     <div class="workout-section">
         <h2>Main Workout (30-35 minutes)</h2>
         <div class="exercise">
-            <p class="exercise-name">A1: Goblet Squats</p>
-            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on keeping your chest up and back straight.</p>
+            <p class="exercise-name">A1: Dumbbell Lunges</p>
+            <p class="sets-reps">4 sets of 10-12 reps per leg. Rest 60 seconds.</p>
+            <p class="notes">Focus on keeping your torso upright.</p>
         </div>
         <div class="exercise">
             <p class="exercise-name">B1: Dumbbell Rows</p>

--- a/workouts/2025-08-18.html
+++ b/workouts/2025-08-18.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Monday, August 18</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,7 +17,7 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
+    <h1>Your Workout for Monday, August 18</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
 
     <div class="workout-section">

--- a/workouts/2025-08-20.html
+++ b/workouts/2025-08-20.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Wednesday, August 20</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,8 +17,8 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
-    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+    <h1>Your Workout for Wednesday, August 20</h1>
+    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>
@@ -41,23 +41,23 @@
     <div class="workout-section">
         <h2>Main Workout (30-35 minutes)</h2>
         <div class="exercise">
-            <p class="exercise-name">A1: Goblet Squats</p>
-            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on keeping your chest up and back straight.</p>
-        </div>
-        <div class="exercise">
-            <p class="exercise-name">B1: Dumbbell Rows</p>
+            <p class="exercise-name">A1: Dumbbell Rows</p>
             <p class="sets-reps">4 sets of 10-12 reps per arm. Rest 60 seconds.</p>
             <p class="notes">Keep your back flat and pull the dumbbell towards your hip.</p>
         </div>
         <div class="exercise">
-            <p class="exercise-name">C1: Romanian Deadlifts (RDLs)</p>
-            <p class="sets-reps">3 sets of 12-15 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on pushing your hips back. Use light weight to start.</p>
+            <p class="exercise-name">B1: Goblet Squats</p>
+            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
+            <p class="notes">Focus on keeping your chest up and back straight.</p>
         </div>
         <div class="exercise">
-            <p class="exercise-name">D1: Plank</p>
+            <p class="exercise-name">C1: Plank</p>
             <p class="sets-reps">3 sets, hold for 30-45 seconds. Rest 45 seconds.</p>
+        </div>
+        <div class="exercise">
+            <p class="exercise-name">D1: Romanian Deadlifts (RDLs)</p>
+            <p class="sets-reps">3 sets of 12-15 reps. Rest 60 seconds.</p>
+            <p class="notes">Focus on pushing your hips back. Use light weight to start.</p>
         </div>
     </div>
 

--- a/workouts/2025-08-22.html
+++ b/workouts/2025-08-22.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Friday, August 22</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,8 +17,8 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
-    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+    <h1>Your Workout for Friday, August 22</h1>
+    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>
@@ -41,9 +41,9 @@
     <div class="workout-section">
         <h2>Main Workout (30-35 minutes)</h2>
         <div class="exercise">
-            <p class="exercise-name">A1: Goblet Squats</p>
-            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on keeping your chest up and back straight.</p>
+            <p class="exercise-name">A1: Dumbbell Lunges</p>
+            <p class="sets-reps">4 sets of 10-12 reps per leg. Rest 60 seconds.</p>
+            <p class="notes">Focus on keeping your torso upright.</p>
         </div>
         <div class="exercise">
             <p class="exercise-name">B1: Dumbbell Rows</p>

--- a/workouts/2025-08-25.html
+++ b/workouts/2025-08-25.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Monday, August 25</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,7 +17,7 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
+    <h1>Your Workout for Monday, August 25</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
 
     <div class="workout-section">

--- a/workouts/2025-08-27.html
+++ b/workouts/2025-08-27.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Wednesday, August 27</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,8 +17,8 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
-    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+    <h1>Your Workout for Wednesday, August 27</h1>
+    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>
@@ -41,23 +41,23 @@
     <div class="workout-section">
         <h2>Main Workout (30-35 minutes)</h2>
         <div class="exercise">
-            <p class="exercise-name">A1: Goblet Squats</p>
-            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on keeping your chest up and back straight.</p>
-        </div>
-        <div class="exercise">
-            <p class="exercise-name">B1: Dumbbell Rows</p>
+            <p class="exercise-name">A1: Dumbbell Rows</p>
             <p class="sets-reps">4 sets of 10-12 reps per arm. Rest 60 seconds.</p>
             <p class="notes">Keep your back flat and pull the dumbbell towards your hip.</p>
         </div>
         <div class="exercise">
-            <p class="exercise-name">C1: Romanian Deadlifts (RDLs)</p>
-            <p class="sets-reps">3 sets of 12-15 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on pushing your hips back. Use light weight to start.</p>
+            <p class="exercise-name">B1: Goblet Squats</p>
+            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
+            <p class="notes">Focus on keeping your chest up and back straight.</p>
         </div>
         <div class="exercise">
-            <p class="exercise-name">D1: Plank</p>
+            <p class="exercise-name">C1: Plank</p>
             <p class="sets-reps">3 sets, hold for 30-45 seconds. Rest 45 seconds.</p>
+        </div>
+        <div class="exercise">
+            <p class="exercise-name">D1: Romanian Deadlifts (RDLs)</p>
+            <p class="sets-reps">3 sets of 12-15 reps. Rest 60 seconds.</p>
+            <p class="notes">Focus on pushing your hips back. Use light weight to start.</p>
         </div>
     </div>
 

--- a/workouts/2025-08-29.html
+++ b/workouts/2025-08-29.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Friday, August 29</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,8 +17,8 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
-    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+    <h1>Your Workout for Friday, August 29</h1>
+    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>
@@ -41,9 +41,9 @@
     <div class="workout-section">
         <h2>Main Workout (30-35 minutes)</h2>
         <div class="exercise">
-            <p class="exercise-name">A1: Goblet Squats</p>
-            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on keeping your chest up and back straight.</p>
+            <p class="exercise-name">A1: Dumbbell Lunges</p>
+            <p class="sets-reps">4 sets of 10-12 reps per leg. Rest 60 seconds.</p>
+            <p class="notes">Focus on keeping your torso upright.</p>
         </div>
         <div class="exercise">
             <p class="exercise-name">B1: Dumbbell Rows</p>

--- a/workouts/2025-09-01.html
+++ b/workouts/2025-09-01.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Monday, September 1</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,7 +17,7 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
+    <h1>Your Workout for Monday, September 1</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
 
     <div class="workout-section">

--- a/workouts/2025-09-03.html
+++ b/workouts/2025-09-03.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Wednesday, September 3</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,8 +17,8 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
-    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+    <h1>Your Workout for Wednesday, September 3</h1>
+    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>
@@ -41,23 +41,23 @@
     <div class="workout-section">
         <h2>Main Workout (30-35 minutes)</h2>
         <div class="exercise">
-            <p class="exercise-name">A1: Goblet Squats</p>
-            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on keeping your chest up and back straight.</p>
-        </div>
-        <div class="exercise">
-            <p class="exercise-name">B1: Dumbbell Rows</p>
+            <p class="exercise-name">A1: Dumbbell Rows</p>
             <p class="sets-reps">4 sets of 10-12 reps per arm. Rest 60 seconds.</p>
             <p class="notes">Keep your back flat and pull the dumbbell towards your hip.</p>
         </div>
         <div class="exercise">
-            <p class="exercise-name">C1: Romanian Deadlifts (RDLs)</p>
-            <p class="sets-reps">3 sets of 12-15 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on pushing your hips back. Use light weight to start.</p>
+            <p class="exercise-name">B1: Goblet Squats</p>
+            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
+            <p class="notes">Focus on keeping your chest up and back straight.</p>
         </div>
         <div class="exercise">
-            <p class="exercise-name">D1: Plank</p>
+            <p class="exercise-name">C1: Plank</p>
             <p class="sets-reps">3 sets, hold for 30-45 seconds. Rest 45 seconds.</p>
+        </div>
+        <div class="exercise">
+            <p class="exercise-name">D1: Romanian Deadlifts (RDLs)</p>
+            <p class="sets-reps">3 sets of 12-15 reps. Rest 60 seconds.</p>
+            <p class="notes">Focus on pushing your hips back. Use light weight to start.</p>
         </div>
     </div>
 

--- a/workouts/2025-09-05.html
+++ b/workouts/2025-09-05.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Friday, September 5</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,8 +17,8 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
-    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+    <h1>Your Workout for Friday, September 5</h1>
+    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>
@@ -41,9 +41,9 @@
     <div class="workout-section">
         <h2>Main Workout (30-35 minutes)</h2>
         <div class="exercise">
-            <p class="exercise-name">A1: Goblet Squats</p>
-            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on keeping your chest up and back straight.</p>
+            <p class="exercise-name">A1: Dumbbell Lunges</p>
+            <p class="sets-reps">4 sets of 10-12 reps per leg. Rest 60 seconds.</p>
+            <p class="notes">Focus on keeping your torso upright.</p>
         </div>
         <div class="exercise">
             <p class="exercise-name">B1: Dumbbell Rows</p>

--- a/workouts/2025-09-08.html
+++ b/workouts/2025-09-08.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Monday, September 8</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,7 +17,7 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
+    <h1>Your Workout for Monday, September 8</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
 
     <div class="workout-section">

--- a/workouts/2025-09-10.html
+++ b/workouts/2025-09-10.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Wednesday, September 10</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,8 +17,8 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
-    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+    <h1>Your Workout for Wednesday, September 10</h1>
+    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>
@@ -41,23 +41,23 @@
     <div class="workout-section">
         <h2>Main Workout (30-35 minutes)</h2>
         <div class="exercise">
-            <p class="exercise-name">A1: Goblet Squats</p>
-            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on keeping your chest up and back straight.</p>
-        </div>
-        <div class="exercise">
-            <p class="exercise-name">B1: Dumbbell Rows</p>
+            <p class="exercise-name">A1: Dumbbell Rows</p>
             <p class="sets-reps">4 sets of 10-12 reps per arm. Rest 60 seconds.</p>
             <p class="notes">Keep your back flat and pull the dumbbell towards your hip.</p>
         </div>
         <div class="exercise">
-            <p class="exercise-name">C1: Romanian Deadlifts (RDLs)</p>
-            <p class="sets-reps">3 sets of 12-15 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on pushing your hips back. Use light weight to start.</p>
+            <p class="exercise-name">B1: Goblet Squats</p>
+            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
+            <p class="notes">Focus on keeping your chest up and back straight.</p>
         </div>
         <div class="exercise">
-            <p class="exercise-name">D1: Plank</p>
+            <p class="exercise-name">C1: Plank</p>
             <p class="sets-reps">3 sets, hold for 30-45 seconds. Rest 45 seconds.</p>
+        </div>
+        <div class="exercise">
+            <p class="exercise-name">D1: Romanian Deadlifts (RDLs)</p>
+            <p class="sets-reps">3 sets of 12-15 reps. Rest 60 seconds.</p>
+            <p class="notes">Focus on pushing your hips back. Use light weight to start.</p>
         </div>
     </div>
 

--- a/workouts/2025-09-12.html
+++ b/workouts/2025-09-12.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workout for Monday, July 21</title>
+    <title>Workout for Friday, September 12</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; }
         h1, h2, h3 { color: #005A9C; }
@@ -17,8 +17,8 @@
 </head>
 <body>
 
-    <h1>Your Workout for Monday, July 21</h1>
-    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+    <h1>Your Workout for Friday, September 12</h1>
+    <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>
@@ -41,9 +41,9 @@
     <div class="workout-section">
         <h2>Main Workout (30-35 minutes)</h2>
         <div class="exercise">
-            <p class="exercise-name">A1: Goblet Squats</p>
-            <p class="sets-reps">4 sets of 8-10 reps. Rest 60 seconds.</p>
-            <p class="notes">Focus on keeping your chest up and back straight.</p>
+            <p class="exercise-name">A1: Dumbbell Lunges</p>
+            <p class="sets-reps">4 sets of 10-12 reps per leg. Rest 60 seconds.</p>
+            <p class="notes">Focus on keeping your torso upright.</p>
         </div>
         <div class="exercise">
             <p class="exercise-name">B1: Dumbbell Rows</p>


### PR DESCRIPTION
## Summary
- generate missing workout pages for the 8‑week plan
- ensure the calendar only links to Monday/Wednesday/Friday workouts
- add ankle mobility stretches to the evening routine
- link each workout page back to the calendar

## Testing
- `python3 -m py_compile $(git ls-files '*.py')` *(fails: the following arguments are required: filenames)*
- `if [ -z "$(git ls-files '*.py')" ]; then echo 'No Python files to check'; fi`

------
https://chatgpt.com/codex/tasks/task_e_687d6962f448832b849fd171f6ceaf38