### PR TITLE
Add weekly progression and barefoot plan to schedule

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -52,6 +52,12 @@
     .rest-day {
         background-color: #e9ecef;
     }
+    .barefoot-schedule {
+        display: block;
+        margin-top: 4px;
+        font-size: 0.8em;
+        color: #007bff;
+    }
 </style>
 </head>
 <body>
@@ -79,6 +85,17 @@
     const calendarBody = document.getElementById('calendar-body');
     let currentDate = new Date(startDate);
 
+    const barefootProgression = {
+        1: 'Barefoot: daily indoors; optional 5-10 min walk.',
+        2: 'Barefoot: 2-3 x 10-15 min walks.',
+        3: 'Barefoot: 2-3 x 15-20 min walks.',
+        4: 'Barefoot: 20 min walk + 2-3 short runs.',
+        5: 'Barefoot: two run/walk sessions & extra walk.',
+        6: 'Barefoot: 10-12 min soft run; 5-8 min mixed.',
+        7: 'Barefoot: 15-20 min soft run; 8-10 min with hard surface.',
+        8: 'Barefoot: 2 mi soft & 1 mi hard run.'
+    };
+
     for (let week = 1; week <= 8; week++) {
         const row = document.createElement('tr');
         for (let day = 1; day <= 7; day++) {
@@ -94,7 +111,8 @@
                 cell.innerHTML = `<a href="${link}">${dayOfMonth} ${month}<br>${dayOfWeek}</a>`;
             } else {
                 cell.classList.add('rest-day');
-                cell.innerHTML = `${dayOfMonth} ${month}<br>Rest`;
+                const bf = barefootProgression[week];
+                cell.innerHTML = `${dayOfMonth} ${month}<br>Rest` + (bf ? `<span class="barefoot-schedule">${bf}</span>` : '');
             }
 
             row.appendChild(cell);

--- a/workouts/2025-07-21.html
+++ b/workouts/2025-07-21.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Monday, July 21</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+<p class="notes">Week 1: Learn the movements with light weight.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-07-23.html
+++ b/workouts/2025-07-23.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Wednesday, July 23</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
+<p class="notes">Week 1: Learn the movements with light weight.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-07-25.html
+++ b/workouts/2025-07-25.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Friday, July 25</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
+<p class="notes">Week 1: Learn the movements with light weight.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-07-28.html
+++ b/workouts/2025-07-28.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Monday, July 28</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+<p class="notes">Week 2: Add 1–2 reps per set if form feels good.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-07-30.html
+++ b/workouts/2025-07-30.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Wednesday, July 30</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
+<p class="notes">Week 2: Add 1–2 reps per set if form feels good.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-08-01.html
+++ b/workouts/2025-08-01.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Friday, August 1</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
+<p class="notes">Week 2: Add 1–2 reps per set if form feels good.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-08-04.html
+++ b/workouts/2025-08-04.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Monday, August 4</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+<p class="notes">Week 3: Increase weight slightly while keeping reps in range.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-08-06.html
+++ b/workouts/2025-08-06.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Wednesday, August 6</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
+<p class="notes">Week 3: Increase weight slightly while keeping reps in range.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-08-08.html
+++ b/workouts/2025-08-08.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Friday, August 8</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
+<p class="notes">Week 3: Increase weight slightly while keeping reps in range.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-08-11.html
+++ b/workouts/2025-08-11.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Monday, August 11</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+<p class="notes">Week 4: Aim to complete 4 sets on each exercise.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-08-13.html
+++ b/workouts/2025-08-13.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Wednesday, August 13</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
+<p class="notes">Week 4: Aim to complete 4 sets on each exercise.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-08-15.html
+++ b/workouts/2025-08-15.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Friday, August 15</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
+<p class="notes">Week 4: Aim to complete 4 sets on each exercise.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-08-18.html
+++ b/workouts/2025-08-18.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Monday, August 18</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+<p class="notes">Week 5: Try harder variations or add weight.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-08-20.html
+++ b/workouts/2025-08-20.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Wednesday, August 20</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
+<p class="notes">Week 5: Try harder variations or add weight.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-08-22.html
+++ b/workouts/2025-08-22.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Friday, August 22</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
+<p class="notes">Week 5: Try harder variations or add weight.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-08-25.html
+++ b/workouts/2025-08-25.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Monday, August 25</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+<p class="notes">Week 6: Focus on controlled tempo; keep progressing weight.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-08-27.html
+++ b/workouts/2025-08-27.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Wednesday, August 27</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
+<p class="notes">Week 6: Focus on controlled tempo; keep progressing weight.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-08-29.html
+++ b/workouts/2025-08-29.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Friday, August 29</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
+<p class="notes">Week 6: Focus on controlled tempo; keep progressing weight.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-09-01.html
+++ b/workouts/2025-09-01.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Monday, September 1</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+<p class="notes">Week 7: Push for your heaviest weights of the cycle.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-09-03.html
+++ b/workouts/2025-09-03.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Wednesday, September 3</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
+<p class="notes">Week 7: Push for your heaviest weights of the cycle.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-09-05.html
+++ b/workouts/2025-09-05.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Friday, September 5</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
+<p class="notes">Week 7: Push for your heaviest weights of the cycle.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-09-08.html
+++ b/workouts/2025-09-08.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Monday, September 8</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength A</p>
+<p class="notes">Week 8: Maintain intensity, prepping for next phase.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-09-10.html
+++ b/workouts/2025-09-10.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Wednesday, September 10</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength B</p>
+<p class="notes">Week 8: Maintain intensity, prepping for next phase.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>

--- a/workouts/2025-09-12.html
+++ b/workouts/2025-09-12.html
@@ -19,6 +19,7 @@
 
     <h1>Your Workout for Friday, September 12</h1>
     <p class="notes">Total Time: 45 minutes | Focus: Full Body Strength C</p>
+<p class="notes">Week 8: Maintain intensity, prepping for next phase.</p>
 
     <div class="workout-section">
         <h2>Warm-up (5-7 minutes)</h2>


### PR DESCRIPTION
## Summary
- note week-by-week progression on each workout page
- show barefoot running schedule on rest days in calendar

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687dd78cad38832b9ed462c0b317354c