### PR TITLE
Add ankle rehab and stretching routine to fitness plan

### DIFF
--- a/fitness-plan-index.html
+++ b/fitness-plan-index.html
@@ -73,6 +73,7 @@
         </tr>
       </tbody>
     </table>
+    <p>For additional joint care, follow the <a href="workouts/ankle_rehab.html">ankle rehab and stretching routine</a> on rest days or after workouts.</p>
     <p>Warm‑up thoroughly and progress gradually. Consult your doctor or physiotherapist if you experience pain【963587572219979†L210-L218】.</p>
     <p>Return to <a href="index.html">Home</a></p>
   </div>

--- a/workouts/ankle_rehab.html
+++ b/workouts/ankle_rehab.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ankle Rehab & Stretching</title>
+  <link rel="stylesheet" href="../css/style/style.css">
+</head>
+<body>
+  <div class="container">
+    <h2>Ankle Rehab &amp; Stretching</h2>
+    <p>Use this simple routine on rest days or after workouts to improve ankle mobility and strengthen supporting muscles.</p>
+    <h3>Rehab Exercises</h3>
+    <ul>
+      <li><strong>Ankle Circles:</strong> 2 sets of 10 each direction.</li>
+      <li><strong>Ankle Alphabet:</strong> Trace the letters A–Z with your toes.</li>
+      <li><strong>Resistance Band Dorsiflexion:</strong> 2 sets of 15 reps.</li>
+      <li><strong>Resistance Band Plantarflexion:</strong> 2 sets of 15 reps.</li>
+    </ul>
+    <h3>Stretching</h3>
+    <ul>
+      <li><strong>Calf Stretch:</strong> Hold 30 seconds per side.</li>
+      <li><strong>Soleus Stretch:</strong> Bend the back knee and hold 30 seconds per side.</li>
+      <li><strong>Plantar Fascia Stretch:</strong> Pull toes back gently and hold 30 seconds per side.</li>
+    </ul>
+    <p><a href="../fitness-plan-index.html">Back to Plan Index</a></p>
+  </div>
+</body>
+</html>

--- a/workouts/week1_rest.html
+++ b/workouts/week1_rest.html
@@ -10,6 +10,7 @@
   <div class="container">
     <h2>Week 1 – Rest & Barefoot Training</h2>
 <p>Daily barefoot time indoors and basic foot‑strengthening exercises (calf raises, toe curls). If comfortable, walk barefoot on soft grass for 5–10 minutes. On two rest days, finish your walk with a short 200‑m barefoot jog【254645292719844†L139-L156】. Remember to progress slowly and listen to your feet; start on soft surfaces and stop if you feel pain【254645292719844†L139-L142】.</p>
+<p>Include <a href="ankle_rehab.html">ankle rehab and stretching</a> to improve mobility and support recovery.</p>
 <p><strong>Reminder:</strong> Keep warming up and cooling down even on rest days. Gentle stretching and mobility exercises will help your recovery.</p>
     <div class="nav-links"><a href="week1_session3.html">Previous</a> | <a href="week2_session1.html">Next</a></div>
     <p><a href="../fitness-plan-index.html">Back to Plan Index</a></p>

--- a/workouts/week2_rest.html
+++ b/workouts/week2_rest.html
@@ -10,6 +10,7 @@
   <div class="container">
     <h2>Week 2 – Rest & Barefoot Training</h2>
 <p>Continue barefoot time at home. Do 2–3 sessions of 10–15‑minute barefoot walks on safe, soft ground. Maintain foot‑strength exercises twice a week and include jog intervals: run 3 × 1‑minute barefoot with 1‑minute walks between【254645292719844†L159-L163】. Stay mindful of form and avoid overstriding by landing gently under your centre of gravity【254645292719844†L216-L219】.</p>
+<p>Include <a href="ankle_rehab.html">ankle rehab and stretching</a> to improve mobility and support recovery.</p>
 <p><strong>Reminder:</strong> Keep warming up and cooling down even on rest days. Gentle stretching and mobility exercises will help your recovery.</p>
     <div class="nav-links"><a href="week2_session3.html">Previous</a> | <a href="week3_session1.html">Next</a></div>
     <p><a href="../fitness-plan-index.html">Back to Plan Index</a></p>

--- a/workouts/week3_rest.html
+++ b/workouts/week3_rest.html
@@ -10,6 +10,7 @@
   <div class="container">
     <h2>Week 3 – Rest & Barefoot Training</h2>
 <p>Maintain daily barefoot time. Walk 15–20 minutes barefoot on varied soft surfaces and focus on foot strike and cadence. After walks, include 3 × 2‑minute barefoot jogs (about 400 m each)【254645292719844†L166-L171】.</p>
+<p>Include <a href="ankle_rehab.html">ankle rehab and stretching</a> to improve mobility and support recovery.</p>
 <p><strong>Reminder:</strong> Keep warming up and cooling down even on rest days. Gentle stretching and mobility exercises will help your recovery.</p>
     <div class="nav-links"><a href="week3_session3.html">Previous</a> | <a href="week4_session1.html">Next</a></div>
     <p><a href="../fitness-plan-index.html">Back to Plan Index</a></p>

--- a/workouts/week4_rest.html
+++ b/workouts/week4_rest.html
@@ -10,6 +10,7 @@
   <div class="container">
     <h2>Week 4 – Rest & Barefoot Training</h2>
 <p>Keep 1–2 barefoot walks of 20 minutes. Begin to add very short 30–60‑second barefoot runs at the end of your walks (2–3 repeats) with a few minutes of walking between them【254645292719844†L174-L178】. Pay attention to any discomfort—if your feet hurt, stick to walking【254645292719844†L174-L180】.</p>
+<p>Include <a href="ankle_rehab.html">ankle rehab and stretching</a> to improve mobility and support recovery.</p>
 <p><strong>Reminder:</strong> Keep warming up and cooling down even on rest days. Gentle stretching and mobility exercises will help your recovery.</p>
     <div class="nav-links"><a href="week4_session3.html">Previous</a> | <a href="week5_session1.html">Next</a></div>
     <p><a href="../fitness-plan-index.html">Back to Plan Index</a></p>

--- a/workouts/week5_rest.html
+++ b/workouts/week5_rest.html
@@ -10,6 +10,7 @@
   <div class="container">
     <h2>Week 5 – Rest & Barefoot Training</h2>
 <p>Perform two barefoot sessions: start with a 10‑minute barefoot walk then incorporate 4–6 minutes of easy barefoot running (e.g., 4–6 × 1‑minute run/1‑minute walk). Add an extra 20–25‑minute barefoot walk on another day and continue foot‑strength work【254645292719844†L182-L187】.</p>
+<p>Include <a href="ankle_rehab.html">ankle rehab and stretching</a> to improve mobility and support recovery.</p>
 <p><strong>Reminder:</strong> Keep warming up and cooling down even on rest days. Gentle stretching and mobility exercises will help your recovery.</p>
     <div class="nav-links"><a href="week5_session3.html">Previous</a> | <a href="week6_session1.html">Next</a></div>
     <p><a href="../fitness-plan-index.html">Back to Plan Index</a></p>

--- a/workouts/week6_rest.html
+++ b/workouts/week6_rest.html
@@ -10,6 +10,7 @@
   <div class="container">
     <h2>Week 6 – Rest & Barefoot Training</h2>
 <p>Do one run on a soft surface (10–12 minutes continuous running or run/walk intervals) and a second mixed‑surface run: after a 5‑minute walk, run 5–8 minutes and include a very short 100–200‑m segment on a smooth hard surface【254645292719844†L189-L193】.</p>
+<p>Include <a href="ankle_rehab.html">ankle rehab and stretching</a> to improve mobility and support recovery.</p>
 <p><strong>Reminder:</strong> Keep warming up and cooling down even on rest days. Gentle stretching and mobility exercises will help your recovery.</p>
     <div class="nav-links"><a href="week6_session3.html">Previous</a> | <a href="week7_session1.html">Next</a></div>
     <p><a href="../fitness-plan-index.html">Back to Plan Index</a></p>

--- a/workouts/week7_rest.html
+++ b/workouts/week7_rest.html
@@ -10,6 +10,7 @@
   <div class="container">
     <h2>Week 7 – Rest & Barefoot Training</h2>
 <p>Complete a 15–20‑minute barefoot run on a soft surface and a second 8–10‑minute run incorporating up to 0.5 mile on a smooth, hard surface【254645292719844†L196-L200】.</p>
+<p>Include <a href="ankle_rehab.html">ankle rehab and stretching</a> to improve mobility and support recovery.</p>
 <p><strong>Reminder:</strong> Keep warming up and cooling down even on rest days. Gentle stretching and mobility exercises will help your recovery.</p>
     <div class="nav-links"><a href="week7_session3.html">Previous</a> | <a href="week8_session1.html">Next</a></div>
     <p><a href="../fitness-plan-index.html">Back to Plan Index</a></p>

--- a/workouts/week8_rest.html
+++ b/workouts/week8_rest.html
@@ -10,6 +10,7 @@
   <div class="container">
     <h2>Week 8 – Rest & Barefoot Training</h2>
 <p>For your final week, aim for a 2‑mile barefoot run on soft surfaces and a 1‑mile run on smooth pavement or track【254645292719844†L203-L207】. Keep focusing on quick cadence, mid‑foot strike and relaxed posture【254645292719844†L216-L223】.</p>
+<p>Include <a href="ankle_rehab.html">ankle rehab and stretching</a> to improve mobility and support recovery.</p>
 <p><strong>Reminder:</strong> Keep warming up and cooling down even on rest days. Gentle stretching and mobility exercises will help your recovery.</p>
     <div class="nav-links"><a href="week8_session3.html">Previous</a> | <span></span></div>
     <p><a href="../fitness-plan-index.html">Back to Plan Index</a></p>


### PR DESCRIPTION
## Summary
- Create dedicated ankle rehab and stretching routine page
- Link ankle rehab routine from rest-day pages and plan index to support joint recovery

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68964fca3610832b9202123bca9d904e