### PR TITLE
feat: Add 12-week integrated rehab and strength plan

### DIFF
--- a/fitness-plan-index.html
+++ b/fitness-plan-index.html
@@ -8,7 +8,9 @@
 </head>
 <body>
   <div class="container">
-    <h1>8‑Week Exercise Plan</h1>
+    <h1>Exercise Plans</h1>
+    <p>For your new 12-week integrated shoulder rehab and strength program, see the <a href="workouts/integrated-rehab-and-strength-plan.html"><strong>Integrated Rehab and Strength Plan</strong></a>.</p>
+    <h2>8-Week Exercise Plan</h2>
     <p>Select a session or rest day below to view details. Each week consists of three workout sessions and one rest day with barefoot training.</p>
     <table>
       <thead>

--- a/workouts/integrated-rehab-and-strength-plan.html
+++ b/workouts/integrated-rehab-and-strength-plan.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Integrated Rehab and Strength Plan</title>
+  <link rel="stylesheet" href="../css/style/style.css">
+  <style>
+    .phase-notes, .general-rules {
+      margin-bottom: 20px;
+      padding: 15px;
+      background-color: #f2f2f2;
+      border-left: 5px solid #007bff;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 30px;
+    }
+    th, td {
+      border: 1px solid #ddd;
+      padding: 8px;
+      text-align: left;
+    }
+    th {
+      background-color: #f2f2f2;
+    }
+    .week-title {
+      margin-top: 40px;
+      margin-bottom: 10px;
+      color: #333;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>12-Week Integrated Rehab & Strength Plan</h1>
+    <p>This plan integrates your existing weightlifting schedule with a phased shoulder rehab program, safe arm accessory work, and karate. Follow the prescribed exercises, sets, reps, and load management guidelines closely.</p>
+    <p>Return to <a href="../fitness-plan-index.html">Main Plan Index</a>.</p>
+
+    <div class="general-rules">
+      <h3>General Rules for Integration</h3>
+      <ul>
+        <li><strong>Priority:</strong> Prioritize scapular and cuff stability exercises first in each session before adding arm isolation.</li>
+        <li><strong>Scheduling:</strong> Slot biceps + triceps training into Tue/Thu (mobility days) OR as finishers after Mon/Wed/Fri rehab sessions.</li>
+        <li><strong>Rep Range:</strong> Use 8–12 rep range, controlled tempo, moderate loads (start light, progress as tolerated).</li>
+        <li><strong>Session Duration:</strong> Ensure total session time is around 35 minutes for the morning slot.</li>
+        <li><strong>Karate:</strong> Karate sessions remain, but avoid aggravating the shoulder (no heavy bag strikes or repetitive overhead blocks until pain-free).</li>
+      </ul>
+    </div>
+
+    <!-- Phase 1: Weeks 1-2 (Mobility) -->
+    <h2>Phase 1: Mobility (Weeks 1–2)</h2>
+    <div class="phase-notes">
+      <p><strong>Focus:</strong> Gentle movement, establishing pain-free range of motion, and basic scapular control. No heavy lifting for the upper body. Main lifts are lower-body focused.</p>
+      <p><strong>Rehab Exercises:</strong> Pendulums, Towel Stretch, Pec Stretch, Scapular Setting, Wall Angels, Isometric Internal Rotation.</p>
+    </div>
+
+    <!-- Week 1 -->
+    <h3 class="week-title">Week 1</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Day</th>
+          <th>Workout Details (Est. 30-35 min)</th>
+          <th>Sets & Reps</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Monday (Strength/Activation)</strong></td>
+          <td>
+            1. Rehab: Scapular Setting, Wall Angels<br>
+            2. Main Lift: Squat (20-50-70-90 kg)<br>
+            3. Finisher (Optional): Hammer Curls
+          </td>
+          <td>
+            Rehab: 2x10-15<br>
+            Squat: 3x5<br>
+            Curls: 2x8-12
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Tuesday (Mobility/Posture)</strong></td>
+          <td>
+            1. Rehab: Pendulums, Towel Stretch, Pec Stretch<br>
+            2. Arm Work: Incline Curls (light), Band Pushdowns
+          </td>
+          <td>
+            Rehab: 2x15-20s holds<br>
+            Arms: 2x10-12 each
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Wednesday (Strength/Activation)</strong></td>
+          <td>
+            1. Rehab: Isometric IR, Scapular Setting<br>
+            2. Main Lift: Deadlift (55-80-100-120 kg)<br>
+            3. Finisher (Optional): Wrist Curls
+          </td>
+          <td>
+            Rehab: 2x10s holds<br>
+            Deadlift: 3x5<br>
+            Curls: 2x10-15
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Thursday (Mobility/Posture)</strong></td>
+          <td>
+            1. Rehab: Pendulums, Pec Stretch, Wall Angels<br>
+            2. Arm Work: Concentration Curls, Overhead Band Extension
+          </td>
+          <td>
+            Rehab: 2x15-20s holds<br>
+            Arms: 2x10-12 each
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Friday (Strength/Activation)</strong></td>
+          <td>
+            1. Rehab: Scapular Setting, Isometric IR<br>
+            2. Main Lift: Goblet Squats (with 20kg or 12kg bell)<br>
+            3. Finisher: Farmer's Carries (light)
+          </td>
+          <td>
+            Rehab: 2x10-15<br>
+            Squats: 3x8-10<br>
+            Carries: 2x30s
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Saturday</strong></td>
+          <td>Karate (Focus on stances, kata, light partner work. No heavy impact.)</td>
+          <td>As per class</td>
+        </tr>
+        <tr>
+          <td><strong>Sunday</strong></td>
+          <td>Rest / Recovery</td>
+          <td>-</td>
+        </tr>
+      </tbody>
+    </table>
+    <!-- Week 2 is a repeat of Week 1, focusing on quality of movement -->
+    <h3 class="week-title">Week 2</h3>
+    <p>Repeat Week 1 schedule, focusing on improving form and control.</p>
+
+    <!-- Phase 2: Weeks 3-6 (Activation) -->
+    <h2>Phase 2: Activation (Weeks 3–6)</h2>
+    <div class="phase-notes">
+      <p><strong>Focus:</strong> Activating and strengthening the rotator cuff and scapular stabilizers. Introduce light pressing and pulling. Continue with main lower body lifts.</p>
+      <p><strong>Rehab Exercises:</strong> Belly-Press Holds, Band IR, Prone Y/T Raises, Wall Push-up Plus, Scaption, Face Pulls, Trap Stretch.</p>
+    </div>
+    <!-- Week 3 -->
+    <h3 class="week-title">Week 3</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Day</th>
+          <th>Workout Details (Est. 30-35 min)</th>
+          <th>Sets & Reps</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Monday (Strength/Activation)</strong></td>
+          <td>
+            1. Rehab: Prone Y/T Raises, Face Pulls<br>
+            2. Main Lift: Squat (Progression)<br>
+            3. Accessory: Light DB Bench Press (20kg)
+          </td>
+          <td>
+            Rehab: 2x10-12<br>
+            Squat: 3x5<br>
+            Bench: 2x8-10 (paused)
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Tuesday (Mobility/Posture)</strong></td>
+          <td>
+            1. Rehab: Trap Stretch, Scaption (light)<br>
+            2. Arm Work: Hammer Curls, Band Pushdowns
+          </td>
+          <td>
+            Rehab: 2x20s holds<br>
+            Arms: 2-3x10-12
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Wednesday (Strength/Activation)</strong></td>
+          <td>
+            1. Rehab: Band IR, Wall Push-up Plus<br>
+            2. Main Lift: Deadlift (Progression)<br>
+            3. Finisher: Reverse Curls
+          </td>
+          <td>
+            Rehab: 2x10-12<br>
+            Deadlift: 3x5<br>
+            Curls: 2x10-15
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Thursday (Mobility/Posture)</strong></td>
+          <td>
+            1. Rehab: Belly-Press Holds, Face Pulls<br>
+            2. Arm Work: Incline Curls, Overhead Band Extension
+          </td>
+          <td>
+            Rehab: 2x15s holds<br>
+            Arms: 2-3x10-12
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Friday (Strength/Activation)</strong></td>
+          <td>
+            1. Rehab: Prone Y/T Raises, Scaption<br>
+            2. Main Lift: Light DB Shoulder Press (20kg)<br>
+            3. Accessory: Inverted Rows (bodyweight)
+          </td>
+          <td>
+            Rehab: 2x10-12<br>
+            Press: 2x8-10 (paused)<br>
+            Rows: 3xAMRAP
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Saturday</strong></td>
+          <td>Karate (Continue with caution)</td>
+          <td>As per class</td>
+        </tr>
+        <tr>
+          <td><strong>Sunday</strong></td>
+          <td>Rest / Recovery</td>
+          <td>-</td>
+        </tr>
+      </tbody>
+    </table>
+    <h3 class="week-title">Weeks 4-6</h3>
+    <p>Continue the Week 3 template. Focus on gradually increasing control and endurance in rehab exercises. For main lifts, slowly progress the weight on Squat and Deadlift. For DB Bench and Shoulder Press, maintain light weight and focus on perfect, pain-free form before considering adding load.</p>
+
+    <!-- Phase 3: Weeks 7-12 (Strength Integration) -->
+    <h2>Phase 3: Strength Integration (Weeks 7–12)</h2>
+    <div class="phase-notes">
+      <p><strong>Focus:</strong> Integrating strength back into compound movements. Gradually increase load on bench press and overhead press. Introduce more complex movements.</p>
+      <p><strong>Rehab Exercises:</strong> Heavier Band IR, Bear-Hug Resistance, Y/T/W Series, Push-up Plus (floor), Rows, Diagonal Press, Overhead Carry.</p>
+    </div>
+    <!-- Week 7 -->
+    <h3 class="week-title">Week 7</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Day</th>
+          <th>Workout Details (Est. 35 min)</th>
+          <th>Sets & Reps</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Monday (Strength/Activation)</strong></td>
+          <td>
+            1. Rehab: Y/T/W Series, Heavier Band IR<br>
+            2. Main Lift: Squat (Progression)<br>
+            3. Main Lift 2: Bench Press (Start light, e.g., 40kg)
+          </td>
+          <td>
+            Rehab: 2x10<br>
+            Squat: 3x5<br>
+            Bench: 3x5 (paused)
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Tuesday (Mobility/Posture)</strong></td>
+          <td>
+            1. Rehab: Diagonal Press (band), Pec Stretch<br>
+            2. Arm Work: Concentration Curls, Tricep Kickbacks
+          </td>
+          <td>
+            Rehab: 2x12<br>
+            Arms: 3x10-12
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Wednesday (Strength/Activation)</strong></td>
+          <td>
+            1. Rehab: Push-up Plus (floor), Bear-Hug Resistance<br>
+            2. Main Lift: Deadlift (Progression)<br>
+            3. Accessory: Rows (dumbbell or barbell)
+          </td>
+          <td>
+            Rehab: 2x10<br>
+            Deadlift: 3x5<br>
+            Rows: 3x8-10
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Thursday (Mobility/Posture)</strong></td>
+          <td>
+            1. Rehab: Overhead Carry (light kettlebell/dumbbell)<br>
+            2. Arm Work: Hammer Curls, Overhead Band Extension
+          </td>
+          <td>
+            Rehab: 2x20m<br>
+            Arms: 3x10-12
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Friday (Strength/Activation)</strong></td>
+          <td>
+            1. Rehab: Y/T/W Series<br>
+            2. Main Lift: Shoulder Press (Start light, e.g., 30kg)<br>
+            3. Accessory: Hangs (dead hang for grip/decompression)
+          </td>
+          <td>
+            Rehab: 2x10<br>
+            Press: 3x5 (paused)<br>
+            Hangs: 3x20-30s
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Saturday</strong></td>
+          <td>Karate (Pain-free strikes can be reintroduced cautiously)</td>
+          <td>As per class</td>
+        </tr>
+        <tr>
+          <td><strong>Sunday</strong></td>
+          <td>Rest / Recovery</td>
+          <td>-</td>
+        </tr>
+      </tbody>
+    </table>
+    <h3 class="week-title">Weeks 8-12</h3>
+    <p>Continue the Week 7 template. The main goal is a gradual and pain-free return to your previous lifting numbers on Bench Press and Shoulder Press. Listen to your body. If the shoulder feels good, you can slowly increase the weight on your main lifts. Introduce Close-Grip Push-ups as a tricep accessory when ready. Continue to prioritize the rehab work at the beginning of each session.</p>
+
+  </div>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a new, comprehensive 12-week workout plan that integrates a phased shoulder rehabilitation program with the user's existing strength training, arm accessory work, and karate schedule.

A new page, `workouts/integrated-rehab-and-strength-plan.html`, has been created to host the detailed plan. The plan is structured into three phases (Mobility, Activation, Strength Integration) and presented in a weekly, tabular format for clarity.

The main index file, `fitness-plan-index.html`, has been updated to include a prominent link to this new plan, ensuring it is easily accessible.