### PR TITLE
Link rehab pages and metronome

### DIFF
--- a/barefoot-days.html
+++ b/barefoot-days.html
@@ -15,14 +15,14 @@
         <tr><th>Week</th><th>Rest Day Activity</th></tr>
       </thead>
       <tbody>
-        <tr><td>1</td><td>On two rest days, warm up with a 5&nbsp;min walk, then jog <strong>200&nbsp;m (or ~1&nbsp;min)</strong> on soft grass. Walk back to cool down.</td></tr>
-        <tr><td>2</td><td>Jog 3&nbsp;×&nbsp;1&nbsp;min on two rest days, walking a minute between runs. Add a short barefoot walk on another rest day.</td></tr>
-        <tr><td>3</td><td>Try 3&nbsp;×&nbsp;2&nbsp;min jogs (or ~400&nbsp;m each) on soft ground. Continue one easy barefoot walk.</td></tr>
-        <tr><td>4</td><td>Finish a 20&nbsp;min walk with 4&nbsp;×&nbsp;1&nbsp;min runs. Keep recovery walks brief.</td></tr>
-        <tr><td>5</td><td>Two run/walk sessions: 6–8&nbsp;min of easy running total. Add one extra 20&nbsp;min walk.</td></tr>
-        <tr><td>6</td><td>Run 10–12&nbsp;min continuously on soft surface once this week. On a second day, run 5–8&nbsp;min, including a short 100–200&nbsp;m stretch on smooth pavement.</td></tr>
-        <tr><td>7</td><td>One run of 15–20&nbsp;min on grass or trail. Another run of 8–10&nbsp;min can include up to 0.5&nbsp;mi on pavement.</td></tr>
-        <tr><td>8</td><td>Target a 2&nbsp;mi run on soft surface and a separate 1&nbsp;mi run on pavement, focusing on light steps and good form.</td></tr>
+        <tr><td>1</td><td>On two rest days, warm up with a 5&nbsp;min walk, then <a href="run-walk-metronome.html">jog <strong>200&nbsp;m (or ~1&nbsp;min)</strong></a> on soft grass. Walk back to cool down.</td></tr>
+        <tr><td>2</td><td><a href="run-walk-metronome.html">Jog 3&nbsp;×&nbsp;1&nbsp;min</a> on two rest days, walking a minute between runs. Add a short barefoot walk on another rest day.</td></tr>
+        <tr><td>3</td><td>Try <a href="run-walk-metronome.html">3&nbsp;×&nbsp;2&nbsp;min jogs</a> (or ~400&nbsp;m each) on soft ground. Continue one easy barefoot walk.</td></tr>
+        <tr><td>4</td><td>Finish a 20&nbsp;min walk with <a href="run-walk-metronome.html">4&nbsp;×&nbsp;1&nbsp;min runs</a>. Keep recovery walks brief.</td></tr>
+        <tr><td>5</td><td>Two <a href="run-walk-metronome.html">run/walk sessions</a>: 6–8&nbsp;min of easy running total. Add one extra 20&nbsp;min walk.</td></tr>
+        <tr><td>6</td><td><a href="run-walk-metronome.html">Run 10–12&nbsp;min continuously</a> on soft surface once this week. On a second day, <a href="run-walk-metronome.html">run 5–8&nbsp;min</a>, including a short 100–200&nbsp;m stretch on smooth pavement.</td></tr>
+        <tr><td>7</td><td>One <a href="run-walk-metronome.html">run of 15–20&nbsp;min</a> on grass or trail. Another <a href="run-walk-metronome.html">run of 8–10&nbsp;min</a> can include up to 0.5&nbsp;mi on pavement.</td></tr>
+        <tr><td>8</td><td>Target a <a href="run-walk-metronome.html">2&nbsp;mi run</a> on soft surface and a separate <a href="run-walk-metronome.html">1&nbsp;mi run</a> on pavement, focusing on light steps and good form.</td></tr>
       </tbody>
     </table>
     <p>Always listen to your feet. If anything feels painful, take extra rest and repeat the previous week.</p>

--- a/barefoot_running_schedule.html
+++ b/barefoot_running_schedule.html
@@ -79,6 +79,10 @@
 <div class="container">
   <h1>8-Week Barefoot Running Schedule</h1>
 
+  <p>Need a timing tool? Use the
+    <a href="run-walk-metronome.html">run/walk cadence metronome</a>
+    to keep your steps in rhythm during jogging intervals.</p>
+
   <div class="tab" role="tablist">
     <button class="tablinks" onclick="openTab(event, 'Overview')" id="defaultOpen" role="tab" aria-controls="Overview" aria-selected="true">Overview & Guidelines</button>
     <button class="tablinks" onclick="openTab(event, 'WeeklyPlan')" role="tab" aria-controls="WeeklyPlan" aria-selected="false">Weekly Plan (Weeks 1–8)</button>
@@ -113,7 +117,7 @@
       <li>✅ <strong>Daily Barefoot Time:</strong> Walk around your house barefoot as much as possible. Focus on how your feet feel on different indoor surfaces.</li>
       <li>✅ <strong>Strength:</strong> Perform lower-leg and foot strength exercises (e.g., calf raises, toe curls, towel scrunches) twice this week.</li>
       <li>✅ <strong>Barefoot Walking (Optional):</strong> If comfortable, walk barefoot for 5-10 minutes on a very safe, soft outdoor surface (e.g., clean grass).</li>
-        <li>✅ <strong>Short Jog:</strong> On two rest days, finish your walk with a 200&nbsp;m (or ~1&nbsp;min) easy jog on soft ground.</li>
+        <li>✅ <strong>Short Jog:</strong> On two rest days, finish your walk with a <a href="run-walk-metronome.html">200&nbsp;m (or ~1&nbsp;min) easy jog</a> on soft ground.</li>
     </ul>
 
     <h3>Week 2: Introducing Outdoor Barefoot Walking</h3>
@@ -121,7 +125,7 @@
       <li>✅ <strong>Daily Barefoot Time:</strong> Continue walking barefoot indoors.</li>
       <li>✅ <strong>Barefoot Walks:</strong> 2-3 sessions of 10-15 minutes of barefoot walking on a safe, soft outdoor surface (grass, soft track).</li>
       <li>✅ <strong>Strength:</strong> Continue lower-leg and foot strength exercises twice this week.</li>
-        <li>✅ <strong>Jog Intervals:</strong> On two rest days, run 3 × 1-min intervals with 1-min walks between sets.</li>
+        <li>✅ <strong>Jog Intervals:</strong> On two rest days, <a href="run-walk-metronome.html">run 3 × 1-min intervals</a> with 1-min walks between sets.</li>
     </ul>
 
     <h3>Week 3: Building Walking Endurance</h3>
@@ -130,42 +134,42 @@
       <li>✅ <strong>Barefoot Walks:</strong> 2-3 sessions of 15-20 minutes of barefoot walking. You can try slightly varied soft surfaces.</li>
       <li>✅ <strong>Strength:</strong> Continue strength exercises.</li>
       <li>✅ <strong>Form Focus:</strong> During walks, pay attention to landing softly and your foot strike.</li>
-        <li>✅ <strong>Jog Progression:</strong> Add 3 × 2-min jogs (roughly 400&nbsp;m each) after your walks.</li>
+        <li>✅ <strong>Jog Progression:</strong> Add <a href="run-walk-metronome.html">3 × 2-min jogs</a> (roughly 400&nbsp;m each) after your walks.</li>
     </ul>
 
     <h3>Week 4: First Barefoot Runs (Very Short)</h3>
     <ul>
       <li>✅ <strong>Barefoot Walks:</strong> Continue with 1-2 walks of 20 minutes.</li>
-      <li>✅ <strong>First Barefoot Runs:</strong> Towards the end of one or two of your barefoot walks, add 2-3 repeats of very short (30-60 seconds) easy barefoot runs on soft grass or sand. Walk for a few minutes between run segments. Total running time should be minimal (e.g., 1-3 minutes).</li>
+      <li>✅ <strong>First Barefoot Runs:</strong> Towards the end of one or two of your barefoot walks, add 2-3 repeats of very short (30-60 seconds) easy barefoot runs on soft grass or sand. Walk for a few minutes between run segments. Total running time should be minimal (e.g., 1-3 minutes). Use the <a href="run-walk-metronome.html">run/walk metronome</a> to keep cadence.</li>
       <li>✅ <strong>Strength:</strong> Continue strength exercises.</li>
       <li><strong>Listen to your feet:</strong> If any pain, stick to walking.</li>
     </ul>
 
     <h3>Week 5: Gradually Increasing Running Time</h3>
     <ul>
-      <li>✅ <strong>Barefoot Sessions:</strong> 2 sessions this week. Start with a 10-minute barefoot walk, then incorporate 4-6 minutes of easy barefoot running (e.g., 4-6 x 1 minute run / 1 minute walk). Focus on soft surfaces.</li>
+      <li>✅ <strong>Barefoot Sessions:</strong> 2 sessions this week. Start with a 10-minute barefoot walk, then incorporate <a href="run-walk-metronome.html">4-6 minutes of easy barefoot running</a> (e.g., 4-6 x 1 minute run / 1 minute walk). Focus on soft surfaces.</li>
       <li>✅ <strong>Strength:</strong> Continue.</li>
       <li>✅ <strong>Barefoot Walking:</strong> One additional 20-25 minute barefoot walk on a separate day.</li>
     </ul>
 
     <h3>Week 6: Consolidating Running & Introducing Harder Surfaces (Briefly)</h3>
     <ul>
-      <li>✅ <strong>Barefoot Run 1 (Soft Surface):</strong> 10-12 minutes of continuous easy running on grass or sand, or use run/walk intervals to achieve this duration.</li>
-      <li>✅ <strong>Barefoot Run 2 (Mixed Surface):</strong> After a 5-minute walk, run for 5-8 minutes. If comfortable, include a very short segment (e.g., 100-200 meters) on a smooth, hard surface like pavement or a running track towards the end of this run. Focus on form.</li>
+      <li>✅ <strong>Barefoot Run 1 (Soft Surface):</strong> <a href="run-walk-metronome.html">10-12 minutes of continuous easy running</a> on grass or sand, or use run/walk intervals to achieve this duration.</li>
+      <li>✅ <strong>Barefoot Run 2 (Mixed Surface):</strong> After a 5-minute walk, <a href="run-walk-metronome.html">run for 5-8 minutes</a>. If comfortable, include a very short segment (e.g., 100-200 meters) on a smooth, hard surface like pavement or a running track towards the end of this run. Focus on form.</li>
       <li>✅ <strong>Strength:</strong> Continue.</li>
     </ul>
 
     <h3>Week 7: Extending Barefoot Runs</h3>
     <ul>
-      <li>✅ <strong>Barefoot Run 1 (Soft Surface):</strong> Aim for 15-20 minutes of barefoot running on a soft surface (approx. 1.5-2 miles for many). This can be continuous or with short walk breaks.</li>
-      <li>✅ <strong>Barefoot Run 2 (Harder Surface Practice):</strong> 8-10 minutes of barefoot running, incorporating up to 0.5 miles on a smooth, hard surface. Pay close attention to form and any discomfort.</li>
+      <li>✅ <strong>Barefoot Run 1 (Soft Surface):</strong> Aim for <a href="run-walk-metronome.html">15-20 minutes of barefoot running</a> on a soft surface (approx. 1.5-2 miles for many). This can be continuous or with short walk breaks.</li>
+      <li>✅ <strong>Barefoot Run 2 (Harder Surface Practice):</strong> <a href="run-walk-metronome.html">8-10 minutes of barefoot running</a>, incorporating up to 0.5 miles on a smooth, hard surface. Pay close attention to form and any discomfort.</li>
       <li>✅ <strong>Strength:</strong> Continue.</li>
     </ul>
 
     <h3>Week 8: Towards Comfortable Barefoot Mileage</h3>
     <ul>
-      <li>✅ <strong>Barefoot Run 1 (Soft Surface):</strong> Target a 2-mile barefoot run on a soft surface like grass or a trail.</li>
-      <li>✅ <strong>Barefoot Run 2 (Hard Surface):</strong> Aim for a 1-mile barefoot run on a smooth, hard surface (e.g., pavement or track). Focus on maintaining good form, quick cadence, and light steps.</li>
+      <li>✅ <strong>Barefoot Run 1 (Soft Surface):</strong> Target a <a href="run-walk-metronome.html">2-mile barefoot run</a> on a soft surface like grass or a trail.</li>
+      <li>✅ <strong>Barefoot Run 2 (Hard Surface):</strong> Aim for a <a href="run-walk-metronome.html">1-mile barefoot run</a> on a smooth, hard surface (e.g., pavement or track). Focus on maintaining good form, quick cadence, and light steps.</li>
       <li>✅ <strong>Strength:</strong> Continue.</li>
       <li><strong>Congratulations!</strong> You have built a solid foundation for barefoot running. Continue to progress gradually and listen to your body.</li>
     </ul>

--- a/fitness-index.html
+++ b/fitness-index.html
@@ -51,6 +51,14 @@
 <body>
   <div class="container">
     <h1>8‑Week Exercise Plan</h1>
+    <div style="padding:1em; background:#fff3cd; border:1px solid #ffeeba; margin-bottom:1em;">
+      <p><strong>Rehab in Progress:</strong> The regular training regimen is on hold while following these resources:</p>
+      <ul>
+        <li><a href="barefoot_running_schedule.html">8-week barefoot running rehab schedule</a></li>
+        <li><a href="week2AugustRehab.html">Week 2 August Rehab</a></li>
+        <li><a href="barefoot-days.html">Barefoot Rest Day Details</a></li>
+      </ul>
+    </div>
     <p>Select a session or rest day below to view details. Each week consists of three workout sessions and one rest day with barefoot training.</p>
     <table>
       <thead>

--- a/fitness-plan-index.html
+++ b/fitness-plan-index.html
@@ -9,6 +9,16 @@
 <body>
   <div class="container">
     <h1>Exercise Plans</h1>
+    <div style="padding:1em; background:#fff3cd; border:1px solid #ffeeba; margin-bottom:1em;">
+      <p><strong>Rehab in Progress:</strong> The regular training regimen is on hold while following the
+        <a href="barefoot_running_schedule.html">8-week barefoot running rehab schedule</a>.</p>
+    </div>
+    <p>Additional rehab pages:</p>
+    <ul>
+      <li><a href="week2AugustRehab.html">Week 2 August Rehab</a></li>
+      <li><a href="barefoot-days.html">Barefoot Rest Day Details</a></li>
+      <li><a href="workouts/ankle_rehab.html">Ankle Rehab and Stretching Routine</a></li>
+    </ul>
     <p>For your new 12-week integrated shoulder rehab and strength program, see the <a href="workouts/integrated-rehab-and-strength-plan.html"><strong>Integrated Rehab and Strength Plan</strong></a>.</p>
     <h2>8-Week Exercise Plan</h2>
     <p>Select a session or rest day below to view details. Each week consists of three workout sessions and one rest day with barefoot training.</p>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,14 @@
 <body>
   <div class="container">
     <h1>8‑Week Exercise Plan</h1>
+    <div style="padding:1em; background:#fff3cd; border:1px solid #ffeeba; margin-bottom:1em;">
+      <p><strong>Rehab in Progress:</strong> The regular training plan is paused while following these resources:</p>
+      <ul>
+        <li><a href="barefoot_running_schedule.html">8-week barefoot running rehab schedule</a></li>
+        <li><a href="week2AugustRehab.html">Week 2 August Rehab</a></li>
+        <li><a href="barefoot-days.html">Barefoot Rest Day Details</a></li>
+      </ul>
+    </div>
     <p>Select a session or rest day below to view details. Each week consists of three workout sessions and one rest day with barefoot training.</p>
     <table>
       <thead>

--- a/run-walk-metronome.html
+++ b/run-walk-metronome.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Run/Walk Cadence Timer</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: 'Montserrat', sans-serif;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: #fff;
+    }
+    .container {
+      background: rgba(255, 255, 255, 0.1);
+      padding: 2rem;
+      border-radius: 12px;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+      backdrop-filter: blur(8px);
+      text-align: center;
+      min-width: 260px;
+    }
+    label {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-top: 1rem;
+    }
+    input {
+      width: 100px;
+      padding: 0.5rem;
+      border: none;
+      border-radius: 6px;
+      text-align: right;
+    }
+    .buttons {
+      margin-top: 1.5rem;
+    }
+    button {
+      margin: 0 0.5rem;
+      padding: 0.6rem 1.2rem;
+      border: none;
+      border-radius: 6px;
+      font-weight: 600;
+      cursor: pointer;
+      background: #fff;
+      color: #333;
+    }
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+    #phase {
+      font-size: 1.5rem;
+      margin-top: 1.5rem;
+    }
+    #timer {
+      font-size: 2rem;
+      margin-top: 0.5rem;
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Run/Walk Cadence Timer</h1>
+    <label>Run Seconds <input type="number" id="runSeconds" value="120" min="1" /></label>
+    <label>Walk Seconds <input type="number" id="walkSeconds" value="60" min="1" /></label>
+    <label>Cadence (BPM) <input type="number" id="bpm" value="170" min="30" /></label>
+    <div class="buttons">
+      <button id="startBtn">Start</button>
+      <button id="stopBtn" disabled>Stop</button>
+    </div>
+    <div id="phase">Stopped</div>
+    <div id="timer">0</div>
+  </div>
+
+  <script>
+    let phase = 'stopped';
+    let remaining = 0;
+    let runSec = 0;
+    let walkSec = 0;
+    let bpm = 170;
+    let intervalId = null;
+    let beepIntervalId = null;
+    let audioCtx = null;
+    let beatCount = 0;
+
+    function beep() {
+      if (!audioCtx) {
+        audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+      }
+      const osc = audioCtx.createOscillator();
+      const gain = audioCtx.createGain();
+      const panner = audioCtx.createStereoPanner ? audioCtx.createStereoPanner() : null;
+      osc.connect(gain);
+      if (panner) {
+        gain.connect(panner);
+        panner.connect(audioCtx.destination);
+      } else {
+        gain.connect(audioCtx.destination);
+      }
+
+      const isLeft = beatCount % 2 === 0;
+      osc.frequency.value = isLeft ? 880 : 800;
+      if (panner) {
+        panner.pan.value = isLeft ? -0.5 : 0.5;
+      }
+      beatCount++;
+
+      osc.start();
+      gain.gain.setValueAtTime(1, audioCtx.currentTime);
+      gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.1);
+      osc.stop(audioCtx.currentTime + 0.1);
+    }
+
+    function updateDisplay() {
+      document.getElementById('phase').textContent = phase.charAt(0).toUpperCase() + phase.slice(1);
+      document.getElementById('timer').textContent = remaining;
+    }
+
+    function startPhase(newPhase) {
+      phase = newPhase;
+      remaining = phase === 'running' ? runSec : walkSec;
+      updateDisplay();
+      if (phase === 'running') {
+        beatCount = 0;
+        beepIntervalId = setInterval(beep, 60000 / bpm);
+      }
+      intervalId = setInterval(() => {
+        remaining--;
+        updateDisplay();
+        if (remaining <= 0) {
+          clearInterval(intervalId);
+          if (phase === 'running') {
+            clearInterval(beepIntervalId);
+            startPhase('walking');
+          } else {
+            startPhase('running');
+          }
+        }
+      }, 1000);
+    }
+
+    document.getElementById('startBtn').addEventListener('click', () => {
+      runSec = parseInt(document.getElementById('runSeconds').value, 10);
+      walkSec = parseInt(document.getElementById('walkSeconds').value, 10);
+      bpm = parseInt(document.getElementById('bpm').value, 10);
+      document.getElementById('startBtn').disabled = true;
+      document.getElementById('stopBtn').disabled = false;
+      startPhase('running');
+    });
+
+    document.getElementById('stopBtn').addEventListener('click', () => {
+      clearInterval(intervalId);
+      clearInterval(beepIntervalId);
+      phase = 'stopped';
+      remaining = 0;
+      beatCount = 0;
+      updateDisplay();
+      document.getElementById('startBtn').disabled = false;
+      document.getElementById('stopBtn').disabled = true;
+    });
+  </script>
+</body>
+</html>

--- a/week2AugustRehab.html
+++ b/week2AugustRehab.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Week 2 – August Rehab</title>
+  <link rel="stylesheet" href="css/style/style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>Week 2 – August Rehab Schedule</h1>
+    <ol>
+      <li>Day 1: Warm up with a 5‑minute walk, then <a href="run-walk-metronome.html">jog 3 × 1‑minute</a> with 1‑minute walks between sets.</li>
+      <li>Day 2: Easy barefoot walk or rest for recovery.</li>
+      <li>Day 3: Repeat Day 1 with another <a href="run-walk-metronome.html">3 × 1‑minute jog</a>, focusing on light steps.</li>
+    </ol>
+    <div class="nav-links">
+      <a href="fitness-plan-index.html">Back to Plan Index</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/workouts/week5_rest.html
+++ b/workouts/week5_rest.html
@@ -9,7 +9,7 @@
 <body>
   <div class="container">
     <h2>Week 5 – Rest & Barefoot Training</h2>
-<p>Perform two barefoot sessions: start with a 10‑minute barefoot walk then incorporate 4–6 minutes of easy barefoot running (e.g., 4–6 × 1‑minute run/1‑minute walk). Add an extra 20–25‑minute barefoot walk on another day and continue foot‑strength work【254645292719844†L182-L187】.</p>
+<p>Perform two barefoot sessions: start with a 10‑minute barefoot walk then incorporate <a href="../run-walk-metronome.html">4–6 minutes of easy barefoot running</a> (e.g., 4–6 × 1‑minute run/1‑minute walk). Add an extra 20–25‑minute barefoot walk on another day and continue foot‑strength work【254645292719844†L182-L187】.</p>
 <p>Include <a href="ankle_rehab.html">ankle rehab and stretching</a> to improve mobility and support recovery.</p>
 <p><strong>Reminder:</strong> Keep warming up and cooling down even on rest days. Gentle stretching and mobility exercises will help your recovery.</p>
     <div class="nav-links"><a href="week5_session3.html">Previous</a> | <a href="week6_session1.html">Next</a></div>

--- a/workouts/week6_rest.html
+++ b/workouts/week6_rest.html
@@ -9,7 +9,7 @@
 <body>
   <div class="container">
     <h2>Week 6 – Rest & Barefoot Training</h2>
-<p>Do one run on a soft surface (10–12 minutes continuous running or run/walk intervals) and a second mixed‑surface run: after a 5‑minute walk, run 5–8 minutes and include a very short 100–200‑m segment on a smooth hard surface【254645292719844†L189-L193】.</p>
+<p>Do one <a href="../run-walk-metronome.html">run on a soft surface</a> (10–12 minutes continuous running or run/walk intervals) and a second mixed‑surface run: after a 5‑minute walk, <a href="../run-walk-metronome.html">run 5–8 minutes</a> and include a very short 100–200‑m segment on a smooth hard surface【254645292719844†L189-L193】.</p>
 <p>Include <a href="ankle_rehab.html">ankle rehab and stretching</a> to improve mobility and support recovery.</p>
 <p><strong>Reminder:</strong> Keep warming up and cooling down even on rest days. Gentle stretching and mobility exercises will help your recovery.</p>
     <div class="nav-links"><a href="week6_session3.html">Previous</a> | <a href="week7_session1.html">Next</a></div>


### PR DESCRIPTION
## Summary
- create Week 2 August rehab schedule with metronome links for each jog
- highlight Week 2 rehab, barefoot rest details, and ankle rehab across fitness index pages
- embed metronome cues in all running instructions throughout rehab documents and rest-day guides

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2aad2b660832bacfcbaa1a4b37978