### PR TITLE
feat: Simplify index and add metronome links

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,89 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>8‑Week Exercise Plan</title>
-  <link rel="stylesheet" href="style.css">
+  <title>Rehab Plan</title>
+  <link rel="stylesheet" href="css/style/style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
 </head>
 <body>
   <div class="container">
-    <h1>8‑Week Exercise Plan</h1>
-    <div style="padding:1em; background:#fff3cd; border:1px solid #ffeeba; margin-bottom:1em;">
-      <p><strong>Rehab in Progress:</strong> The regular training plan is paused while following these resources:</p>
-      <ul>
-        <li><a href="barefoot_running_schedule.html">8-week barefoot running rehab schedule</a></li>
-        <li><a href="week2AugustRehab.html">Week 2 August Rehab</a></li>
-        <li><a href="barefoot-days.html">Barefoot Rest Day Details</a></li>
-      </ul>
-    </div>
-    <p>Select a session or rest day below to view details. Each week consists of three workout sessions and one rest day with barefoot training.</p>
-    <table>
-      <thead>
-        <tr><th>Week</th><th>Session 1</th><th>Session 2</th><th>Session 3</th><th>Rest Day</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Week 1</td>
-          <td><a href="week1_session1.html">Lower Body Foundation</a></td>
-          <td><a href="week1_session2.html">Upper Body & Shoulder Rehab</a></td>
-          <td><a href="week1_session3.html">Kettlebell & Core Circuit</a></td>
-          <td><a href="week1_rest.html">Rest & Barefoot</a></td>
-        </tr>
-        <tr>
-          <td>Week 2</td>
-          <td><a href="week2_session1.html">Lower Body Progression</a></td>
-          <td><a href="week2_session2.html">Push & Pull</a></td>
-          <td><a href="week2_session3.html">Full‑Body Circuit</a></td>
-          <td><a href="week2_rest.html">Rest & Barefoot</a></td>
-        </tr>
-        <tr>
-          <td>Week 3</td>
-          <td><a href="week3_session1.html">Posterior Chain & Single‑Leg Strength</a></td>
-          <td><a href="week3_session2.html">Upper Body Strength & Rehab</a></td>
-          <td><a href="week3_session3.html">Kettlebell Flow & Conditioning</a></td>
-          <td><a href="week3_rest.html">Rest & Barefoot</a></td>
-        </tr>
-        <tr>
-          <td>Week 4</td>
-          <td><a href="week4_session1.html">Lower Body Strength</a></td>
-          <td><a href="week4_session2.html">Upper Body Balance</a></td>
-          <td><a href="week4_session3.html">Kettlebell Complex & Core</a></td>
-          <td><a href="week4_rest.html">Rest & Barefoot</a></td>
-        </tr>
-        <tr>
-          <td>Week 5</td>
-          <td><a href="week5_session1.html">Deadlift & Squat Focus</a></td>
-          <td><a href="week5_session2.html">Push–Pull & Shoulder Care</a></td>
-          <td><a href="week5_session3.html">Conditioning & Core Circuit</a></td>
-          <td><a href="week5_rest.html">Rest & Barefoot</a></td>
-        </tr>
-        <tr>
-          <td>Week 6</td>
-          <td><a href="week6_session1.html">Compound Strength</a></td>
-          <td><a href="week6_session2.html">Upper Body & Overhead Work</a></td>
-          <td><a href="week6_session3.html">Kettlebell & Barbell Complex</a></td>
-          <td><a href="week6_rest.html">Rest & Barefoot</a></td>
-        </tr>
-        <tr>
-          <td>Week 7</td>
-          <td><a href="week7_session1.html">Advanced Leg Strength</a></td>
-          <td><a href="week7_session2.html">Upper Body Strength Challenge</a></td>
-          <td><a href="week7_session3.html">Mobility & Conditioning</a></td>
-          <td><a href="week7_rest.html">Rest & Barefoot</a></td>
-        </tr>
-        <tr>
-          <td>Week 8</td>
-          <td><a href="week8_session1.html">Final Leg Progression</a></td>
-          <td><a href="week8_session2.html">Upper Body Finale</a></td>
-          <td><a href="week8_session3.html">Challenge Circuit</a></td>
-          <td><a href="week8_rest.html">Rest & Barefoot</a></td>
-        </tr>
-      </tbody>
-    </table>
-    <p>Warm‑up thoroughly and progress gradually. Consult your doctor or physiotherapist if you experience pain.</p>
-    <p>Return to <a href="index.html">Home</a></p>
+    <h1>Rehab Plan</h1>
+    <ul>
+      <li><a href="week1AugustRehab.html">Week 1 August Rehab</a></li>
+      <li><a href="week2AugustRehab.html">Week 2 August Rehab</a></li>
+      <li><a href="week3AugustRehab.html">Week 3 August Rehab</a></li>
+      <li><a href="week4AugustRehab.html">Week 4 August Rehab</a></li>
+      <li><a href="run-walk-metronome.html">Run/Walk Metronome</a></li>
+    </ul>
   </div>
 </body>
 </html>

--- a/week1AugustRehab.html
+++ b/week1AugustRehab.html
@@ -73,7 +73,7 @@
     <li><b>Weights days:</b> use <b>2 sets</b> of <b>6–8 reps</b> at <b>RPE 5–6</b> (easy). Stop with 2–3 reps in reserve and rest ~60–90 s.</li>
     <li><b>Elbow isometrics:</b> <b>20–30 s × 3</b> holds at 4–5/10 effort. If the next day feels great, you can add a 4th hold.</li>
     <li><b>Grip:</b> neutral grips where possible; <b>straps allowed</b> on hinge work if elbow talks.</li>
-    <li><b>Running:</b> keep it conversational, quiet feet. If next‑morning calf/Achilles stiffness > 60 min, repeat the same volume.</li>
+    <li><b>Running:</b> <a href="run-walk-metronome.html">Running:</a> keep it conversational, quiet feet. If next‑morning calf/Achilles stiffness > 60 min, repeat the same volume.</li>
   </ul>
 </section>
 
@@ -169,7 +169,7 @@
       <details><summary><b>Tibialis Raise</b> — 2×15</summary>
         <ul class="list check"><li>Back to wall; heels down; lift toes toward shins; slow tempo.</li></ul>
       </details>
-      <details><summary><b>Run – Week 1 Session A</b> — 5’ walk → 4× (30s jog / 90s walk) → 5’ walk</summary>
+      <details><summary><b><a href="run-walk-metronome.html">Run</a> – Week 1 Session A</b> — 5’ walk → 4× (30s jog / 90s walk) → 5’ walk</summary>
         <ul class="list check"><li>Cadence ~170–180; land under center; <b>quiet</b> feet; posture tall with slight forward lean from ankles.</li></ul>
         <ul class="list danger"><li>If calf/Achilles stiffness lasts >60 min next morning, repeat this volume before progressing.</li></ul>
       </details>
@@ -259,7 +259,7 @@
       <details><summary><b>Tibialis Raise</b> — 2×15</summary>
         <ul class="list check"><li>Back to wall; heels down; lift toes toward shins; slow tempo.</li></ul>
       </details>
-      <details><summary><b>Run – Week 1 Session B</b> — 5’ walk → 4× (30s jog / 90s walk) → 5’ walk</summary>
+      <details><summary><b><a href="run-walk-metronome.html">Run</a> – Week 1 Session B</b> — 5’ walk → 4× (30s jog / 90s walk) → 5’ walk</summary>
         <ul class="list check"><li>Cadence ~170–180; land under center; <b>quiet</b> feet; posture tall with slight forward lean from ankles.</li></ul>
         <ul class="list danger"><li>If calf/Achilles stiffness lasts >60 min next morning, repeat this volume before progressing.</li></ul>
       </details>
@@ -345,7 +345,7 @@
       <details><summary><b>Tibialis Raise</b> — 2×15</summary>
         <ul class="list check"><li>Back to wall; heels down; lift toes toward shins; slow tempo.</li></ul>
       </details>
-      <details><summary><b>Run – Week 1 Session C</b> — 5’ walk → 4× (30s jog / 90s walk) → 5’ walk</summary>
+      <details><summary><b><a href="run-walk-metronome.html">Run</a> – Week 1 Session C</b> — 5’ walk → 4× (30s jog / 90s walk) → 5’ walk</summary>
         <ul class="list check"><li>Cadence ~170–180; land under center; <b>quiet</b> feet; posture tall with slight forward lean from ankles.</li></ul>
         <ul class="list danger"><li>If calf/Achilles stiffness lasts >60 min next morning, repeat this volume before progressing.</li></ul>
       </details>

--- a/week2AugustRehab.html
+++ b/week2AugustRehab.html
@@ -73,7 +73,7 @@
     <ul>
       <li><b>Goblet Squat, RDL:</b> <b>2×8 @ RPE ≤6</b> (was 2×6–8). Same tempo/cues.</li>
       <li><b>Elbow isometrics:</b> <b>20–30s ×3–4 @ 4–5/10</b> (optional +1 hold vs W1).</li>
-      <li><b>Run sessions:</b> <b>6× (45s jog / 75s walk)</b> between 5′ warm-up/cool-down.</li>
+      <li><b><a href="run-walk-metronome.html">Run sessions:</a></b> <b>6× (45s jog / 75s walk)</b> between 5′ warm-up/cool-down.</li>
       <li>Grip neutral where possible; straps allowed on hinge work if elbow talks.</li>
     </ul>
   </section>
@@ -166,7 +166,7 @@
         <details><summary><b>Tibialis Raise</b> — 2×15</summary>
           <ul class="list check"><li>Back to wall; heels down; lift toes toward shins; slow tempo.</li></ul>
         </details>
-        <details><summary><b>Run – Week 2 Session A</b> — 5’ walk → <b>6× (45s jog / 75s walk)</b> → 5’ walk <span class="pill">volume bump</span></summary>
+        <details><summary><b><a href="run-walk-metronome.html">Run</a> – Week 2 Session A</b> — 5’ walk → <b>6× (45s jog / 75s walk)</b> → 5’ walk <span class="pill">volume bump</span></summary>
           <ul class="list check"><li>Cadence ~170–180; land under center; <b>quiet</b> feet; posture tall with slight forward lean from ankles.</li></ul>
           <ul class="list danger"><li>If next-morning calf/Achilles stiffness &gt;60 min, repeat this session next time rather than progressing.</li></ul>
         </details>
@@ -256,7 +256,7 @@
         <details><summary><b>Tibialis Raise</b> — 2×15</summary>
           <ul class="list check"><li>Back to wall; heels down; lift toes toward shins; slow tempo.</li></ul>
         </details>
-        <details><summary><b>Run – Week 2 Session B</b> — 5’ walk → <b>6× (45s jog / 75s walk)</b> → 5’ walk</summary>
+        <details><summary><b><a href="run-walk-metronome.html">Run</a> – Week 2 Session B</b> — 5’ walk → <b>6× (45s jog / 75s walk)</b> → 5’ walk</summary>
           <ul class="list check"><li>Cadence ~170–180; land under center; <b>quiet</b> feet; posture tall with slight forward lean from ankles.</li></ul>
           <ul class="list danger"><li>Same rule: if next-morning stiffness &gt;60 min, repeat this volume before progressing.</li></ul>
         </details>
@@ -346,7 +346,7 @@
         <details><summary><b>Tibialis Raise</b> — 2×15</summary>
           <ul class="list check"><li>Back to wall; heels down; lift toes toward shins; slow tempo.</li></ul>
         </details>
-        <details><summary><b>Run – Week 2 Session C</b> — 5’ walk → <b>6× (45s jog / 75s walk)</b> → 5’ walk</summary>
+        <details><summary><b><a href="run-walk-metronome.html">Run</a> – Week 2 Session C</b> — 5’ walk → <b>6× (45s jog / 75s walk)</b> → 5’ walk</summary>
           <ul class="list check"><li>Cadence ~170–180; land under center; <b>quiet</b> feet; posture tall with slight forward lean from ankles.</li></ul>
           <ul class="list danger"><li>Maintain easy effort; stop early if calves complain.</li></ul>
         </details>

--- a/week3AugustRehab.html
+++ b/week3AugustRehab.html
@@ -53,7 +53,7 @@
     <li><b>Goblet Squat, RDL:</b> <b>3×6–8 @ RPE 6–7</b>. Technique first; add reps before load.</li>
     <li><b>Upper add‑ins:</b> <b>Chest‑Supported Row (neutral)</b> 3×10–12; <b>Incline Push‑Up Plus</b> 2×10–12.</li>
     <li><b>Elbow:</b> <b>Eccentric wrist extension 3×8–10</b> (3s down), + light <b>pronation/supination 2×12</b>. Keep isometrics for flare control only.</li>
-    <li><b>Run sessions:</b> <b>8× (60s jog / 60s walk)</b> between 5′ warm‑up/cool‑down.</li>
+    <li><b><a href="run-walk-metronome.html">Run sessions:</a></b> <b>8× (60s jog / 60s walk)</b> between 5′ warm‑up/cool‑down.</li>
     <li>Grip neutral where possible; straps allowed on hinge work if elbow talks.</li>
   </ul>
 </section>
@@ -152,7 +152,7 @@
       <details><summary><b>Tibialis Raise</b> — 2×15</summary>
         <ul class="list check"><li>Back to wall; heels down; lift toes toward shins; slow tempo.</li></ul>
       </details>
-      <details><summary><b>Run – Week 3 Session A</b> — 5’ walk → <b>8× (60s jog / 60s walk)</b> → 5’ walk <span class="pill">volume bump</span></summary>
+      <details><summary><b><a href="run-walk-metronome.html">Run</a> – Week 3 Session A</b> — 5’ walk → <b>8× (60s jog / 60s walk)</b> → 5’ walk <span class="pill">volume bump</span></summary>
         <ul class="list check"><li>Cadence ~170–180; land under center; <b>quiet</b> feet; posture tall with slight forward lean from ankles.</li></ul>
         <ul class="list danger"><li>If next‑morning calf/Achilles stiffness >60 min, repeat this volume before progressing.</li></ul>
       </details>
@@ -216,7 +216,7 @@
       <details><summary><b>Tibialis Raise</b> — 2×15</summary>
         <ul class="list check"><li>Back to wall; heels down; toes up under control.</li></ul>
       </details>
-      <details><summary><b>Run – Week 3 Session B</b> — 5’ walk → <b>8× (60s jog / 60s walk)</b> → 5’ walk</summary>
+      <details><summary><b><a href="run-walk-metronome.html">Run</a> – Week 3 Session B</b> — 5’ walk → <b>8× (60s jog / 60s walk)</b> → 5’ walk</summary>
         <ul class="list check"><li>Cadence ~170–180; quiet midfoot landings; posture tall.</li></ul>
         <ul class="list danger"><li>If stiffness >60 min next morning, repeat this volume before progressing.</li></ul>
       </details>
@@ -278,7 +278,7 @@
       <details><summary><b>Tibialis Raise</b> — 2×15</summary>
         <ul class="list check"><li>Back to wall; heels down; slow controlled reps.</li></ul>
       </details>
-      <details><summary><b>Run – Week 3 Session C</b> — 5’ walk → <b>8× (60s jog / 60s walk)</b> → 5’ walk</summary>
+      <details><summary><b><a href="run-walk-metronome.html">Run</a> – Week 3 Session C</b> — 5’ walk → <b>8× (60s jog / 60s walk)</b> → 5’ walk</summary>
         <ul class="list check"><li>Quiet landings, tall posture, easy effort.</li></ul>
         <ul class="list danger"><li>Stop early if calves/Achilles grumble; repeat volume if morning stiffness >60 min.</li></ul>
       </details>

--- a/week4AugustRehab.html
+++ b/week4AugustRehab.html
@@ -53,7 +53,7 @@
     <li><b>Goblet Squat, RDL:</b> <b>3×6–8 @ RPE 6–7</b>. If Monday is clean next day, add <b>+1 rep</b> to the <i>first</i> set on Wed/Fri or micro‑load 2.5 kg.</li>
     <li><b>Upper add‑ins:</b> <b>Chest‑Supported Row (neutral)</b> 3×10–12; <b>Incline Push‑Up Plus</b> 2–3×8–12 (slightly lower the incline if form is crisp).</li>
     <li><b>Elbow:</b> continue <b>Eccentric wrist extension 3×8–10</b> (3s down) + <b>pronation/supination 2–3×12</b>. Keep a single <b>isometric “calm set”</b> handy for flare control (instructions included below).</li>
-    <li><b>Run sessions:</b> <b>6× (90s jog / 60s walk)</b> between 5′ warm‑up/cool‑down (≈9 min jog total). Repeat volume if next‑morning calf/Achilles stiffness >60 min.</li>
+    <li><b><a href="run-walk-metronome.html">Run sessions:</a></b> <b>6× (90s jog / 60s walk)</b> between 5′ warm‑up/cool‑down (≈9 min jog total). Repeat volume if next‑morning calf/Achilles stiffness >60 min.</li>
     <li>Grip neutral where possible; straps allowed on hinge work if elbow talks.</li>
   </ul>
 </section>
@@ -137,7 +137,7 @@
       <details><summary><b>Tibialis Raise</b> — 2×15</summary>
         <ul class="list check"><li>Back to wall; heels down; lift toes toward shins; control the lower; keep knees soft.</li></ul>
       </details>
-      <details><summary><b>Run – Week 4 Session A</b> — 5’ walk → <b>6× (90s jog / 60s walk)</b> → 5’ walk <span class="pill">longer bouts</span></summary>
+      <details><summary><b><a href="run-walk-metronome.html">Run</a> – Week 4 Session A</b> — 5’ walk → <b>6× (90s jog / 60s walk)</b> → 5’ walk <span class="pill">longer bouts</span></summary>
         <ul class="list check"><li>Cadence ~170–180; land under center; <b>quiet</b> feet; posture tall with slight forward lean from ankles.</li></ul>
         <ul class="list danger"><li>If next‑morning calf/Achilles stiffness >60 min, repeat this volume before progressing.</li></ul>
       </details>
@@ -211,7 +211,7 @@
       <details><summary><b>Tibialis Raise</b> — 2×15</summary>
         <ul class="list check"><li>Back to wall; heels down; toes up under control.</li></ul>
       </details>
-      <details><summary><b>Run – Week 4 Session B</b> — 5’ walk → <b>6× (90s jog / 60s walk)</b> → 5’ walk</summary>
+      <details><summary><b><a href="run-walk-metronome.html">Run</a> – Week 4 Session B</b> — 5’ walk → <b>6× (90s jog / 60s walk)</b> → 5’ walk</summary>
         <ul class="list check"><li>Cadence ~170–180; quiet midfoot landings; posture tall.</li></ul>
         <ul class="list danger"><li>If stiffness >60 min next morning, repeat this volume before progressing.</li></ul>
       </details>
@@ -283,7 +283,7 @@
       <details><summary><b>Tibialis Raise</b> — 2×15</summary>
         <ul class="list check"><li>Back to wall; heels down; slow, controlled reps.</li></ul>
       </details>
-      <details><summary><b>Run – Week 4 Session C</b> — 5’ walk → <b>6× (90s jog / 60s walk)</b> → 5’ walk</summary>
+      <details><summary><b><a href="run-walk-metronome.html">Run</a> – Week 4 Session C</b> — 5’ walk → <b>6× (90s jog / 60s walk)</b> → 5’ walk</summary>
         <ul class="list check"><li>Quiet landings; tall posture; easy effort.</li></ul>
         <ul class="list danger"><li>Stop early if calves/Achilles grumble; repeat volume if morning stiffness >60 min.</li></ul>
       </details>


### PR DESCRIPTION
- The index page is updated to only show links to the four August rehab weeks and the run/walk metronome.
- A link to the run/walk metronome is added to each point where running or jogging is mentioned in the rehab pages.