### PR TITLE
Add kumite technique guide and surface it in fitness resources

### DIFF
--- a/resources/fitness-hub.html
+++ b/resources/fitness-hub.html
@@ -80,6 +80,11 @@
       <li><a href="../apps/run-walk-metronome/legacy.html">Original Run/Walk Metronome (Single File)</a></li>
     </ul>
 
+    <h2>Skill Practice</h2>
+    <ul>
+      <li><a href="karate-kumite-guide.html">Kumite Technique Guide</a> — progressions for karate footwork, striking combinations, and defensive counters.</li>
+    </ul>
+
     <h2>Health Tools</h2>
     <ul>
       <li><a href="../apps/health-calculators/index.html">Health Calculators</a></li>

--- a/resources/fitness.html
+++ b/resources/fitness.html
@@ -14,6 +14,7 @@
     <ul>
       <li><a href="../plans/fitness-plan-index.html">12&#8209;Week Exercise Plan</a></li>
       <li><a href="fitness-hub.html">Training &amp; App Hub</a></li>
+      <li><a href="karate-kumite-guide.html">Kumite Technique Guide</a> — structured karate footwork, striking, and defence drills.</li>
       <li><a href="../apps/run-walk-metronome/index.html">Running Cadence Timer (PWA)</a></li>
     </ul>
 

--- a/resources/karate-kumite-guide.html
+++ b/resources/karate-kumite-guide.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kumite Technique Guide</title>
+  <link rel="stylesheet" href="../css/style/style.css">
+  <style>
+    .callout {
+      background: #e9f7ef;
+      border-left: 4px solid #169B62;
+      padding: 1rem 1.25rem;
+      margin: 1.5rem 0;
+      border-radius: 10px;
+    }
+    .two-column {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1.5rem;
+      margin: 1.5rem 0;
+    }
+    .two-column section {
+      background: #ffffff;
+      border: 1px solid #e0e0e0;
+      border-radius: 12px;
+      padding: 1rem 1.25rem;
+      box-shadow: 0 8px 20px rgba(0,0,0,0.04);
+    }
+    .tech-list {
+      margin: 0;
+      padding-left: 1.25rem;
+      list-style: none;
+    }
+    .tech-list li {
+      position: relative;
+      padding-left: 1.5rem;
+      margin-bottom: 0.85rem;
+    }
+    .tech-list li::before {
+      content: "🥋";
+      position: absolute;
+      left: 0;
+      top: 0;
+    }
+    .practice-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 2rem;
+    }
+    .practice-table th,
+    .practice-table td {
+      border: 1px solid #e0e0e0;
+      padding: 0.85rem 1rem;
+      vertical-align: top;
+    }
+    .practice-table th {
+      background: #f5fdf8;
+      font-weight: 600;
+      color: #169B62;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Kumite Technique Guide</h1>
+    <p>This kumite session plan is organised to help you build confident footwork, crisp striking mechanics, and safe defensive habits. Use it as a standalone karate workout or pair sections with strength and conditioning days.</p>
+
+    <div class="callout">
+      <h3>Safety &amp; Focus Points</h3>
+      <ul>
+        <li>Start every session with a dynamic warm-up and joint mobilisation.</li>
+        <li>Emphasise relaxed shoulders and hips—speed comes from staying loose until impact.</li>
+        <li>Control distance: practice entering and exiting on angles rather than moving straight in.</li>
+        <li>Finish with light stretching and breath work to bring your nervous system back down.</li>
+      </ul>
+    </div>
+
+    <h2>Structured Warm-up (10 minutes)</h2>
+    <ul class="tech-list">
+      <li>Jump-rope or light jog – 2 minutes to raise core temperature.</li>
+      <li>Hip circles, knee hugs, and ankle rolls – 1 minute each.</li>
+      <li>Dynamic leg swings (front/back and side/side) – 12 each leg.</li>
+      <li>Shadowbox with relaxed guard, focusing on smooth breathing – 3 minutes.</li>
+    </ul>
+
+    <h2>Footwork &amp; Guard Drills</h2>
+    <div class="two-column">
+      <section>
+        <h3>Balance &amp; Posture</h3>
+        <ul class="tech-list">
+          <li>Fighting stance holds: 3×30 seconds each side, checking weight distribution.</li>
+          <li>Forward/backward slides: 3×20 steps maintaining level change and guard height.</li>
+          <li>Lateral shuffles with quick guard reset: 3×15 seconds both directions.</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Angles &amp; Entries</h3>
+        <ul class="tech-list">
+          <li>V-step entry with jab: 3×10 repetitions, focus on pushing off the rear foot.</li>
+          <li>Pivot-and-exit drill after a combo: 3×8 reps, end in guard facing opponent.</li>
+          <li>Triangle step shadow sparring: 2×1 minute, mixing in feints before committing.</li>
+        </ul>
+      </section>
+    </div>
+
+    <h2>Striking Combos</h2>
+    <div class="two-column">
+      <section>
+        <h3>Single Techniques</h3>
+        <ul class="tech-list">
+          <li><strong>Oi-zuki (lunge punch):</strong> 4×6 reps each side, accelerate from hips.</li>
+          <li><strong>Gyaku-zuki (reverse punch):</strong> 4×8 reps, rotate rear hip and snap back to guard.</li>
+          <li><strong>Mae-geri (front kick):</strong> 4×6 reps per leg, emphasise knee lift then snap.</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Combinations</h3>
+        <ul class="tech-list">
+          <li>Jab → reverse punch → lead leg roundhouse (mawashi-geri) – 3×8 sequences.</li>
+          <li>Feint jab → step-off angle → reverse punch – 3×6 sequences.</li>
+          <li>Front kick → back leg sweep entry (de-ashi-barai pattern) – 3×5 controlled reps.</li>
+        </ul>
+      </section>
+    </div>
+
+    <h2>Defence &amp; Counter Work</h2>
+    <ul class="tech-list">
+      <li>High guard parry to counter jab: 3×10 reps emphasising minimal movement.</li>
+      <li>Slip outside reverse punch and counter gyaku-zuki: 3×8 reps each side.</li>
+      <li>Check mae-geri with rear hand, counter mawashi-geri low: 3×6 reps per leg.</li>
+      <li>Partner drill: controlled tag sparring at 40% intensity for 3×2-minute rounds.</li>
+    </ul>
+
+    <h2>Conditioning Finisher (Optional)</h2>
+    <ul class="tech-list">
+      <li>30 seconds fast jab-cross shadowboxing.</li>
+      <li>30 seconds alternating front kicks.</li>
+      <li>30 seconds sprawl to fighting stance.</li>
+      <li>Rest 30 seconds and repeat the cycle 3 times.</li>
+    </ul>
+
+    <h2>Weekly Kumite Focus</h2>
+    <table class="practice-table">
+      <thead>
+        <tr>
+          <th>Day</th>
+          <th>Primary Goal</th>
+          <th>Key Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Day 1</td>
+          <td>Footwork &amp; guard foundation</td>
+          <td>Keep tempo relaxed; review angles before adding speed.</td>
+        </tr>
+        <tr>
+          <td>Day 2</td>
+          <td>Striking mechanics</td>
+          <td>Film a few rounds of shadowboxing to check hip rotation.</td>
+        </tr>
+        <tr>
+          <td>Day 3</td>
+          <td>Defence and counters</td>
+          <td>Work with a partner or heavy bag to feel timing.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p class="nav-links"><a href="fitness.html">⬅ Back to Fitness Resources</a><a href="../index.html">Home</a></p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated kumite technique guide covering footwork, striking, defence and conditioning drills
- link the new guide from the main fitness resource index and the fitness hub skill section

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d712289e40832bb740d99268721f43