### PR TITLE
Add Sanbon Kumite coaching sheet card

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,9 +179,18 @@
             <span class="card__badge">Karate</span>
           </div>
           <p>Complete kumite session builder with warm-up integration, drill modules and weekly emphasis planner.</p>
-          <p class="card__meta"><a href="resources/karate-warmup.html">Warm-up flow</a> · <a href="resources/kumite_techniques_full.html#weekly">Weekly plan</a></p>
+          <p class="card__meta"><a href="resources/karate-warmup.html">Warm-up flow</a> · <a href="resources/kumite_techniques_full.html#weekly">Weekly plan</a> · <a href="resources/moveCoaching.html">Coaching sheet</a></p>
           <p><strong><a href="resources/kumite_techniques_full.html">Open the full Kumite Technique Library →</a></strong></p>
 
+        </article>
+        <article class="card">
+          <div class="card__title">
+            <a href="resources/moveCoaching.html">Sanbon Kumite Coaching Sheet</a>
+            <span class="card__badge">Karate</span>
+          </div>
+          <p>Bilingual step breakdowns pair Japanese calls with English cues.</p>
+          <p>A sidedness toggle keeps partner rotations even.</p>
+          <p class="card__meta">Includes printable layout optimized for dojo floor reference.</p>
         </article>
         <article class="card">
           <div class="card__title">


### PR DESCRIPTION
## Summary
- add a Reference Library card for the Sanbon Kumite Coaching Sheet resource with descriptive copy and karate badge
- link the existing Karate Kumite Practice card to the new coaching sheet for quick cross navigation

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4c917ca20832b8f1b8938834711e6