### PR TITLE
Fix gedan-barai sidedness in move coaching guide

### DIFF
--- a/resources/moveCoaching.html
+++ b/resources/moveCoaching.html
@@ -198,8 +198,8 @@
       <div class="step">
         <div class="n">3</div><div>
           <div class="def"><b>Defend:</b>
-            <span class="side-R">Step <b>Right</b> back to <b>left</b> zenkutsu; <mark>gedan-barai</mark> with <b>left</b> arm (sweep down the kicking line).</span>
-            <span class="side-L">Step <b>Left</b> back to <b>right</b> zenkutsu; <mark>gedan-barai</mark> with <b>right</b> arm.</span>
+            <span class="side-R">Step <b>Right</b> back to <b>left</b> zenkutsu; <mark>gedan-barai</mark> with <b>right</b> arm (sweep down the kicking line).</span>
+            <span class="side-L">Step <b>Left</b> back to <b>right</b> zenkutsu; <mark>gedan-barai</mark> with <b>left</b> arm.</span>
             <div class="var foot">
               <b>Footwork:</b> Retreat slightly <i>off the center</i> ~<span class="angle">10–15°</span> to the outside of the kicking leg; weight drops to absorb impact.
             </div>


### PR DESCRIPTION
## Summary
- correct the defender arm notation for the gedan-barai in sanbon kumite drill #1 when starting on the right pattern
- ensure the mirrored left-side instructions now reflect the opposite arm for clarity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e51677779c832bbd28bd399314fcd1